### PR TITLE
Feat/ PageTemplate 구현

### DIFF
--- a/src/pages/PageTemplate/index.jsx
+++ b/src/pages/PageTemplate/index.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as S from './style';
+import BottomBar from '../../feature/BottomBar';
+import Header from '../../feature/Header';
+
+const PageTemplate = ({ children, page }) => {
+  return (
+    <S.PageTemplate>
+      <Header />
+      <S.Section>{children}</S.Section>
+      <BottomBar page={page} />
+    </S.PageTemplate>
+  );
+};
+PageTemplate.propTypes = {
+  page: PropTypes.string.isRequired,
+};
+
+export default PageTemplate;

--- a/src/pages/PageTemplate/index.stories.jsx
+++ b/src/pages/PageTemplate/index.stories.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PageTemplate from '.';
+
+// 'mainFeed', 'ranking', 'search', 'user'
+export default {
+  title: 'Component/PageTemplate',
+  component: PageTemplate,
+  argTypes: {
+    page: {
+      defaultValue: 'mainFeed',
+      control: 'radio',
+      options: ['mainFeed', 'ranking', 'search', 'user'],
+    },
+  },
+};
+export const Default = (args) => {
+  return <PageTemplate {...args} />;
+};

--- a/src/pages/PageTemplate/style.jsx
+++ b/src/pages/PageTemplate/style.jsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+import backgroundImage from '../../../public/background.png';
+
+export const PageTemplate = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+
+  background-image: url(${backgroundImage});
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  background-attachment: fixed;
+`;
+
+export const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 80px 16px;
+`;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
각 페이지마다 공통적으로 사용되는 Template 구현

![Kapture 2022-06-13 at 15 55 08](https://user-images.githubusercontent.com/76620786/173297741-e3595d59-4d62-4e5c-900d-1c6ad66d2502.gif)


### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- Header, BottomBar, children으로 구성되어 있습니다
- children은 각 페이지의 contents를 의미합니다

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
<img width="1219" alt="스크린샷 2022-06-13 오후 3 56 17" src="https://user-images.githubusercontent.com/76620786/173297950-9bc17980-83ea-44f3-8d5a-06f68b19e0f0.png">

- 만약 props로 받아오는 children의 height가 100vh보다 작을 경우 background-image가 다 안보입니다
- 해결하는 방법: 1. children에서 최소 height 100vh 이상 주면 됨 2. css 조정 (전 어떻게 할 지 찾아봐도 잘 안나와서 ㅠㅠ)

### 🤔나머지 생각할 부분
- BottomBar 위치가 page 정중앙이 아님
- Header가 전 디자인으로 구성되어 있어서 지금 디자인으로 바꿔야 함 (알림 아이콘 추가)  

#20 