### PR TITLE
#31/routing : 라우팅 기본적인 환경설정 및 적용 예시

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "prettier": "^2.6.2",
     "prop-types": "^15.8.1",
+    "react-router-dom": "^6.3.0",
     "webpack": "^5.73.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,24 @@
 import React from 'react';
 import { ThemeProvider } from '@emotion/react';
+import { Route, Routes, Navigate } from 'react-router-dom';
 import GlobalStyle from './commons/style/GlobalStyle';
 import theme from './commons/style/themes';
+import NotFoundPage from './pages/NotFound';
+import BottomBar from './feature/BottomBar';
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <div>Test</div>
+      <Routes>
+        <Route path="/main" element={<BottomBar page="mainfeed" />} />
+        <Route path="/cardDetail" element={<NotFoundPage />} />
+        <Route path="/ranking" element={<NotFoundPage />} />
+        <Route path="/TTaBong" element={<NotFoundPage />} />
+        <Route path="/search" element={<NotFoundPage />} />
+        <Route path="/userProfile" element={<NotFoundPage />} />
+        <Route path="/*" element={<BottomBar />} />
+      </Routes>
     </ThemeProvider>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,21 +3,29 @@ import { ThemeProvider } from '@emotion/react';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import GlobalStyle from './commons/style/GlobalStyle';
 import theme from './commons/style/themes';
+import {
+  CardDetailPage,
+  MainPage,
+  RankPage,
+  SearchPage,
+  TTaBongPage,
+  UserProfilePage,
+} from './pages';
 import NotFoundPage from './pages/NotFound';
-import BottomBar from './feature/BottomBar';
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <Routes>
-        <Route path="/main" element={<BottomBar page="mainfeed" />} />
-        <Route path="/cardDetail" element={<NotFoundPage />} />
-        <Route path="/ranking" element={<NotFoundPage />} />
-        <Route path="/TTaBong" element={<NotFoundPage />} />
-        <Route path="/search" element={<NotFoundPage />} />
-        <Route path="/userProfile" element={<NotFoundPage />} />
-        <Route path="/*" element={<BottomBar />} />
+        <Route path="/main/*" element={<MainPage />} />
+        <Route path="/cardDetail/*" element={<CardDetailPage />} />
+        <Route path="/rank/*" element={<RankPage />} />
+        <Route path="/TTaBong/*" element={<TTaBongPage />} />
+        <Route path="/search/*" element={<SearchPage />} />
+        <Route path="/userProfile/*" element={<UserProfilePage />} />
+        <Route path="/error/*" element={<NotFoundPage />} />
+        <Route path="/*" element={<Navigate to="/main" />} />
       </Routes>
     </ThemeProvider>
   );

--- a/src/feature/BottomBar/index.jsx
+++ b/src/feature/BottomBar/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import * as S from './style';
 import Icon from '../../components/Icon';
 
@@ -8,27 +9,37 @@ const BottomBar = ({ page }) => {
   return (
     <S.BottomBarContainer>
       <S.IconContainer>
-        <Icon
-          name={page === 'mainFeed' ? 'listFill' : 'listLine'}
-          alt="리스트 아이콘"
-        />
-        <Icon
-          name={page === 'ranking' ? 'rankingFill' : 'rankingLine'}
-          alt="랭킹 아이콘"
-        />
+        <Link to="/main">
+          <Icon
+            name={page === 'mainFeed' ? 'listFill' : 'listLine'}
+            alt="리스트 아이콘"
+          />
+        </Link>
+        <Link to="/rank">
+          <Icon
+            name={page === 'ranking' ? 'rankingFill' : 'rankingLine'}
+            alt="랭킹 아이콘"
+          />
+        </Link>
       </S.IconContainer>
       <S.TTaBongContainerBox>
-        <Icon name="TTaBongWhite" alt="따봉 아이콘" />
+        <Link to="/TTaBong">
+          <Icon name="TTaBongWhite" alt="따봉 아이콘" />
+        </Link>
       </S.TTaBongContainerBox>
       <S.IconContainer>
-        <Icon
-          name={page === 'search' ? 'searchFill' : 'searchLine'}
-          alt="검색 아이콘"
-        />
-        <Icon
-          name={page === 'user' ? 'userFill' : 'userLine'}
-          alt="유저 아이콘"
-        />
+        <Link to="/search">
+          <Icon
+            name={page === 'search' ? 'searchFill' : 'searchLine'}
+            alt="검색 아이콘"
+          />
+        </Link>
+        <Link to="/userProfile">
+          <Icon
+            name={page === 'user' ? 'userFill' : 'userLine'}
+            alt="유저 아이콘"
+          />
+        </Link>
       </S.IconContainer>
     </S.BottomBarContainer>
   );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import { css } from '@emotion/react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 
 const style = css`
@@ -28,12 +29,14 @@ function AnotherComponent() {
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <SomeComponent>
-      <AnotherComponent />
-      <App />
-    </SomeComponent>
-  </React.StrictMode>,
+  <Router>
+    <React.StrictMode>
+      <SomeComponent>
+        <AnotherComponent />
+        <App />
+      </SomeComponent>
+    </React.StrictMode>
+  </Router>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/pages/CardDetailPage/index.jsx
+++ b/src/pages/CardDetailPage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CardDetailPage = () => {
+  return <div>CardDetail Page</div>;
+};
+
+export default CardDetailPage;

--- a/src/pages/LoginPage/index.jsx
+++ b/src/pages/LoginPage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LoginPage = () => {
+  return <div>Login Page</div>;
+};
+
+export default LoginPage;

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MainPage = () => {
+  return <div>main page</div>;
+};
+
+export default MainPage;

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import BottomPage from '../../feature/BottomBar';
 
 const MainPage = () => {
-  return <div>main page</div>;
+  return <BottomPage page="mainFeed" />;
 };
 
 export default MainPage;

--- a/src/pages/NotFound/index.jsx
+++ b/src/pages/NotFound/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const NotFoundPage = () => {
+  return <div>Not Found</div>;
+};
+
+export default NotFoundPage;

--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const RankPage = () => {
+  return <div>rank page</div>;
+};
+
+export default RankPage;

--- a/src/pages/SearchPage/index.jsx
+++ b/src/pages/SearchPage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SearchPage = () => {
+  return <div>Search Page</div>;
+};
+
+export default SearchPage;

--- a/src/pages/SignupPage/index.jsx
+++ b/src/pages/SignupPage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SignupPage = () => {
+  return <div>Signup Page</div>;
+};
+
+export default SignupPage;

--- a/src/pages/TTaBongPage/index.jsx
+++ b/src/pages/TTaBongPage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TTaBongPage = () => {
+  return <div>TTaBong Page</div>;
+};
+
+export default TTaBongPage;

--- a/src/pages/UserProfilePage/index.jsx
+++ b/src/pages/UserProfilePage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const UserProfilePage = () => {
+  return <div>UserProfile Page</div>;
+};
+
+export default UserProfilePage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,12 @@
+export { default as MainPage } from './MainPage';
+export { default as RankPage } from './RankPage';
+export { default as TTaBongPage } from './TTaBongPage';
+export { default as SearchPage } from './SearchPage';
+export { default as UserProfilePage } from './UserProfilePage';
+
+export { default as LoginPage } from './LoginPage';
+export { default as SignupPage } from './SignupPage';
+
+export { default as CardDetailPage } from './CardDetailPage';
+
+export { default as NotFound } from './NotFound';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7926,6 +7926,13 @@ highlight.js@^10.4.1, highlight.js@~10.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -11942,6 +11949,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->


https://user-images.githubusercontent.com/19660039/173513039-20fc7882-85a6-49f8-b2f6-847b96c81222.mov
(맥에선 억떡혜 gif로 화면 녹화 하나요??????)
라우팅을 위한 라이브러리 설치, 환경설정 및 바텀바 적용

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- react-router-dom v6 설치
yarn install로 라이브러리 설치해주세요

0. 페이지들 임시로 폴더, index.jsx만 구현해놨습니다.
<img width="200" alt="image" src="https://user-images.githubusercontent.com/19660039/173514288-ffc45d49-7388-44ec-9e2c-2a589d83f40b.png">
/pages/index.js 에서 한번에 다시 export 합니다.

2. Router
/src/index.js에 Router(BrowseRouter)로 App을 감쌌습니다.

3. Route Matcher
App.jsx에서 라우팅하도록 하였습니다.
정해진 페이지 이외는 일단 main으로 라우팅시켰습니다.

4. Navigator
바텀바에 <Link to="">children icon</ Link> 적용시켰습니다.
임시로 MainPage에 바텀바만 넣어놨으니 메인페이지에서 확인하실 수 있습니다.

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

- react-router-dom v5 -> v6 로 인한 변경점
Switch 대신 Routes를 사용합니다.
Route의 props로 component 대신 element에 jsx 객체를 전달합니다.
exact props 삭제되고 기본적으로 exact로 작동합니다.
뒷부분을 포함시키려면 '*'을 사용합니다. (ex. /main/*)

- 페이지이름을 좀 더 간결하게
mainFeed -> main
ranking -> rank
로 수정하였습니다. 어떻게 생각하시나요?
(관련해서 야이콘 이름도 바뀔 수 있습니다.)

- NavItem 필요할까요?
예전 프로젝트에선 Nav기능을 달린 버튼만 따로 하나 개발해서 그걸 베이스로 썼습니다.
그러나 지금은 아이콘, 카드, userInfoItem, 로고 등 다양한 곳에 링크 기능이 들어갈 것 같은데 이 경우 모든 곳에 재사용성있게 쓰이려면 아래의 형태일 것 같습니다.
<img width="360" alt="image" src="https://user-images.githubusercontent.com/19660039/173514600-b3ec86ee-14d4-4423-81c3-822ae6662442.png">

그런데 이 형태가 사실
<img width="234" alt="image" src="https://user-images.githubusercontent.com/19660039/173514661-0425fd3a-5010-44ff-9bac-b799ca861308.png">
애초에 <Link> 안에 children node 넣는 거랑 다를게 없어서 굳이 필요한가 싶습니다.

어떻게 생각하시나요?