### PR TITLE
Feat/ UserInfoItem 구현

### DIFF
--- a/src/components/UserInfoItem/index.jsx
+++ b/src/components/UserInfoItem/index.jsx
@@ -6,11 +6,11 @@ const UserInfoItem = ({
   rank,
   avatarImg,
   userName,
-  coinCount = -1,
-  TTaBongCount = -1,
+  coin = null,
+  TTaBong = null,
 }) => {
   return (
-    <S.UserInfoItem>
+    <S.UserInfoItemContanier>
       <S.ImageContainer>
         {rank && (
           <S.RankContainer rank={rank}>
@@ -22,21 +22,21 @@ const UserInfoItem = ({
         </S.AvatarContainer>
       </S.ImageContainer>
       <S.UserNameContainer>{userName}</S.UserNameContainer>
-      <S.TotalCountContainer>
-        {coinCount >= 0 && (
-          <S.CountContainer>
+      <S.CountContainer>
+        {coin && (
+          <S.CountWrapper>
             <S.CountTitle>총 코인수</S.CountTitle>
-            <S.CountSpan>{coinCount}</S.CountSpan>
-          </S.CountContainer>
+            <S.CountSpan>{coin}</S.CountSpan>
+          </S.CountWrapper>
         )}
-        {TTaBongCount >= 0 && (
-          <S.CountContainer>
+        {TTaBong && (
+          <S.CountWrapper>
             <S.CountTitle>총 따봉수</S.CountTitle>
-            <S.CountSpan>{TTaBongCount}</S.CountSpan>
-          </S.CountContainer>
+            <S.CountSpan>{TTaBong}</S.CountSpan>
+          </S.CountWrapper>
         )}
-      </S.TotalCountContainer>
-    </S.UserInfoItem>
+      </S.CountContainer>
+    </S.UserInfoItemContanier>
   );
 };
 
@@ -44,9 +44,9 @@ UserInfoItem.propTypes = {
   rank: PropTypes.number,
   avatarImg: PropTypes.string,
   userName: PropTypes.string.isRequired,
-  coinCount: PropTypes.number,
-  TTaBongCount: PropTypes.number,
-  // coinCount와 TTaBongCount 둘 중 하나 이상은 필수
+  coin: PropTypes.number,
+  TTaBong: PropTypes.number,
+  // coinCount와 TTaBong 둘 중 하나 이상은 필수
 };
 
 export default UserInfoItem;

--- a/src/components/UserInfoItem/index.jsx
+++ b/src/components/UserInfoItem/index.jsx
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+import * as S from './style';
+import Avatar from '../Avatar';
+
+const UserInfoItem = ({
+  rank,
+  avatarImg,
+  userName,
+  coinCount = -1,
+  TTaBongCount = -1,
+}) => {
+  return (
+    <S.UserInfoItem>
+      <S.ImageContainer>
+        {rank && (
+          <S.RankContainer rank={rank}>
+            <S.Rank>{rank}</S.Rank>
+          </S.RankContainer>
+        )}
+        <S.AvatarContainer>
+          <Avatar src={avatarImg} size={40} />
+        </S.AvatarContainer>
+      </S.ImageContainer>
+      <S.UserNameContainer>{userName}</S.UserNameContainer>
+      <S.TotalCountContainer>
+        {coinCount >= 0 && (
+          <S.CountContainer>
+            <S.CountTitle>총 코인수</S.CountTitle>
+            <S.CountSpan>{coinCount}</S.CountSpan>
+          </S.CountContainer>
+        )}
+        {TTaBongCount >= 0 && (
+          <S.CountContainer>
+            <S.CountTitle>총 따봉수</S.CountTitle>
+            <S.CountSpan>{TTaBongCount}</S.CountSpan>
+          </S.CountContainer>
+        )}
+      </S.TotalCountContainer>
+    </S.UserInfoItem>
+  );
+};
+
+UserInfoItem.propTypes = {
+  rank: PropTypes.number,
+  avatarImg: PropTypes.string,
+  userName: PropTypes.string.isRequired,
+  coinCount: PropTypes.number,
+  TTaBongCount: PropTypes.number,
+  // coinCount와 TTaBongCount 둘 중 하나 이상은 필수
+};
+
+export default UserInfoItem;

--- a/src/components/UserInfoItem/index.jsx
+++ b/src/components/UserInfoItem/index.jsx
@@ -11,7 +11,7 @@ const UserInfoItem = ({
 }) => {
   return (
     <S.UserInfoItemContanier>
-      <S.ImageContainer>
+      <S.RankerContainer>
         {rank && (
           <S.RankContainer rank={rank}>
             <S.Rank>{rank}</S.Rank>
@@ -20,8 +20,8 @@ const UserInfoItem = ({
         <S.AvatarContainer>
           <Avatar src={avatarImg} size={40} />
         </S.AvatarContainer>
-      </S.ImageContainer>
-      <S.UserNameContainer>{userName}</S.UserNameContainer>
+      </S.RankerContainer>
+      <S.UserNameWrapper>{userName}</S.UserNameWrapper>
       <S.CountContainer>
         {coin && (
           <S.CountWrapper>

--- a/src/components/UserInfoItem/index.stories.jsx
+++ b/src/components/UserInfoItem/index.stories.jsx
@@ -13,12 +13,12 @@ export default {
       defaultValue: '',
       control: 'text',
     },
-    coinCount: {
-      defaultValue: '-1',
+    coin: {
+      defaultValue: null,
       control: 'number',
     },
-    TTaBongCount: {
-      defaultValue: '-1',
+    TTaBong: {
+      defaultValue: null,
       control: 'number',
     },
   },

--- a/src/components/UserInfoItem/index.stories.jsx
+++ b/src/components/UserInfoItem/index.stories.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import UserInfoItem from '.';
+
+export default {
+  title: 'Components/UserInfoItem',
+  component: UserInfoItem,
+  argTypes: {
+    rank: {
+      defaultValue: '',
+      control: 'number',
+    },
+    userName: {
+      defaultValue: '',
+      control: 'text',
+    },
+    coinCount: {
+      defaultValue: '-1',
+      control: 'number',
+    },
+    TTaBongCount: {
+      defaultValue: '-1',
+      control: 'number',
+    },
+  },
+};
+export const Default = (args) => {
+  return <UserInfoItem {...args} />;
+};

--- a/src/components/UserInfoItem/style.jsx
+++ b/src/components/UserInfoItem/style.jsx
@@ -13,7 +13,7 @@ export const UserInfoItemContanier = styled.div`
   border-radius: 40px 17px 17px 40px;
 `;
 
-export const ImageContainer = styled.div`
+export const RankerContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -82,7 +82,7 @@ export const AvatarContainer = styled.div`
   display: flex;
 `;
 
-export const UserNameContainer = styled.div`
+export const UserNameWrapper = styled.div`
   max-width: 120px;
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/UserInfoItem/style.jsx
+++ b/src/components/UserInfoItem/style.jsx
@@ -1,0 +1,114 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+export const UserInfoItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  width: 292px;
+  height: 55px;
+  background: ${({ theme }) => theme.colors.white};
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.25);
+  border-radius: 40px 17px 17px 40px;
+`;
+
+export const ImageContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  margin-left: 8px;
+  gap: 8px;
+`;
+
+const SilverRankStyle = ({ theme }) => css`
+  background: linear-gradient(
+    to bottom right,
+    ${theme.colors.silver[0]},
+    ${theme.colors.silver[1]}
+  );
+`;
+
+const BronzeRankStyle = ({ theme }) => css`
+  background: linear-gradient(
+    to bottom right,
+    ${theme.colors.bronze[0]},
+    ${theme.colors.bronze[1]}
+  );
+`;
+
+const DefaultRankStyle = ({ theme }) => css`
+  background: ${theme.colors.skyblue[0]};
+`;
+
+export const RankContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  ${({ rank }) => {
+    switch (rank) {
+      case 2:
+        return SilverRankStyle;
+      case 3:
+        return BronzeRankStyle;
+      default:
+        return DefaultRankStyle;
+    }
+  }};
+`;
+
+export const Rank = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 36px;
+  height: 36px;
+  margin: 2px;
+
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 50%;
+  border: 2px solid;
+  font-weight: 600;
+  font-size: 24px;
+`;
+
+export const AvatarContainer = styled.div`
+  display: flex;
+`;
+
+export const UserNameContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const TotalCountContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  gap: 8px;
+  margin-right: 8px;
+`;
+
+export const CountContainer = styled.dl`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const CountTitle = styled.dt`
+  color: ${({ theme }) => theme.colors.darkgray[1]};
+  font-size: 8px;
+`;
+
+export const CountSpan = styled.dd`
+  font-size: 20px;
+  font-weight: 700;
+`;

--- a/src/components/UserInfoItem/style.jsx
+++ b/src/components/UserInfoItem/style.jsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 
-export const UserInfoItem = styled.div`
+export const UserInfoItemContanier = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 
   width: 292px;
   height: 55px;
@@ -82,12 +83,13 @@ export const AvatarContainer = styled.div`
 `;
 
 export const UserNameContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  max-width: 120px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
-export const TotalCountContainer = styled.div`
+export const CountContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -96,7 +98,7 @@ export const TotalCountContainer = styled.div`
   margin-right: 8px;
 `;
 
-export const CountContainer = styled.dl`
+export const CountWrapper = styled.dl`
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
브랜치명 : `\#36/Feat/UserInfoItem`

- ranking 페이지에 적용되는 UserInfoItem
![스크린샷 2022-06-14 오후 6 07 19](https://user-images.githubusercontent.com/76620786/173540443-cc77c44a-1f16-45b9-87f0-625aeb832b8b.png)

- search 페이지에 적용되는 UserInfoItem
![스크린샷 2022-06-14 오후 6 06 54](https://user-images.githubusercontent.com/76620786/173540511-691b25e2-4eb5-4c1b-a5d9-bbb22087efa9.png)

랭크와 아바타 이미지를 겹치게 만들면 검색페이지에 재활용하기 어려울 것 같습니다 (css position 문제)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- props
  - rank : 순위 (필수 아님)
  - avatarImg: 아바타 이미지 (아바타 이미지 src)
  - userName: 사용자 이름 (필수)
  - coinCount: 코인 갯수
  - TTaBongCount: 따봉 갯수

- 랭크 페이지에서 사용되는 userInfo는 기존의 디자인에서 살짝 수정되어 있습니다. (저의 css 한계)
- rank 색깔은 2는 silver, 3은 bronze, 나머지는 skyblue[0]으로 했습니다
- px, rem 중 일단 px로 설정하고 만들었습니다

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
- 변수명에 대해 좋은 의견있으면 올려주세요! (너무 어렵슴다)
- style 디테일한 부분은 추후에 고쳐야할 것 같네요 (폰트 사이즈, px-> rem)

### 연관된 이슈
closed #36 