### PR TITLE
#44/Feat/ RankFirstInfo 구현

### DIFF
--- a/src/feature/rank/RankFirstInfo/index.jsx
+++ b/src/feature/rank/RankFirstInfo/index.jsx
@@ -2,7 +2,12 @@ import PropTypes from 'prop-types';
 import Avatar from '../../../components/Avatar';
 import * as S from './style';
 
-const RankFirstInfo = ({ avatarImg, userName, coin = -1, TTaBong = -1 }) => {
+const RankFirstInfo = ({
+  avatarImg,
+  userName,
+  coinCount = -1,
+  TTaBongCount = -1,
+}) => {
   return (
     <S.RankFirstContainer>
       <S.RankFirstWrapper>현재 1위</S.RankFirstWrapper>
@@ -13,16 +18,16 @@ const RankFirstInfo = ({ avatarImg, userName, coin = -1, TTaBong = -1 }) => {
         </S.AvatarBox>
         <S.InfoBox>
           <S.UserNameWrapper>{userName}</S.UserNameWrapper>
-          {TTaBong >= 0 && (
+          {TTaBongCount >= 0 && (
             <S.TotalCount>
               <S.CountTitle>총 따봉수</S.CountTitle>
-              <S.CountNum>{TTaBong}</S.CountNum>
+              <S.CountNum>{TTaBongCount}</S.CountNum>
             </S.TotalCount>
           )}
-          {coin >= 0 && (
+          {coinCount >= 0 && (
             <S.TotalCount>
               <S.CountTitle>총 코인수</S.CountTitle>
-              <S.CountNum>{coin}</S.CountNum>
+              <S.CountNum>{coinCount}</S.CountNum>
             </S.TotalCount>
           )}
         </S.InfoBox>
@@ -34,8 +39,8 @@ const RankFirstInfo = ({ avatarImg, userName, coin = -1, TTaBong = -1 }) => {
 RankFirstInfo.propTypes = {
   avatarImg: PropTypes.string,
   userName: PropTypes.string.isRequired,
-  coin: PropTypes.number,
-  TTaBong: PropTypes.number,
+  coinCount: PropTypes.number,
+  TTaBongCount: PropTypes.number,
 };
 
 export default RankFirstInfo;

--- a/src/feature/rank/RankFirstInfo/index.jsx
+++ b/src/feature/rank/RankFirstInfo/index.jsx
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types';
+import Avatar from '../../../components/Avatar';
+import * as S from './style';
+
+const RankFirstInfo = ({
+  avatarImg,
+  userName,
+  coin = null,
+  TTaBong = null,
+}) => {
+  return (
+    <S.RankFirstContainer>
+      <S.RankFirstWrapper>현재 1위</S.RankFirstWrapper>
+      <S.RankFirstInfoWrapper>
+        <S.AvatarBox>
+          {/* 왕관 이미지? */}
+          <Avatar src={avatarImg} />
+        </S.AvatarBox>
+        <S.InfoBox>
+          <S.UserNameWrapper>{userName}</S.UserNameWrapper>
+          {TTaBong && (
+            <S.TotalCount>
+              <S.CountTitle>총 따봉수</S.CountTitle>
+              <S.CountNum>{TTaBong}</S.CountNum>
+            </S.TotalCount>
+          )}
+          {coin && (
+            <S.TotalCount>
+              <S.CountTitle>총 코인수</S.CountTitle>
+              <S.CountNum>{coin}</S.CountNum>
+            </S.TotalCount>
+          )}
+        </S.InfoBox>
+      </S.RankFirstInfoWrapper>
+    </S.RankFirstContainer>
+  );
+};
+
+RankFirstInfo.propTypes = {
+  avatarImg: PropTypes.string,
+  userName: PropTypes.string.isRequired,
+  coin: PropTypes.number,
+  TTaBong: PropTypes.number,
+};
+
+export default RankFirstInfo;

--- a/src/feature/rank/RankFirstInfo/index.jsx
+++ b/src/feature/rank/RankFirstInfo/index.jsx
@@ -2,12 +2,7 @@ import PropTypes from 'prop-types';
 import Avatar from '../../../components/Avatar';
 import * as S from './style';
 
-const RankFirstInfo = ({
-  avatarImg,
-  userName,
-  coin = null,
-  TTaBong = null,
-}) => {
+const RankFirstInfo = ({ avatarImg, userName, coin = -1, TTaBong = -1 }) => {
   return (
     <S.RankFirstContainer>
       <S.RankFirstWrapper>현재 1위</S.RankFirstWrapper>
@@ -18,13 +13,13 @@ const RankFirstInfo = ({
         </S.AvatarBox>
         <S.InfoBox>
           <S.UserNameWrapper>{userName}</S.UserNameWrapper>
-          {TTaBong && (
+          {TTaBong >= 0 && (
             <S.TotalCount>
               <S.CountTitle>총 따봉수</S.CountTitle>
               <S.CountNum>{TTaBong}</S.CountNum>
             </S.TotalCount>
           )}
-          {coin && (
+          {coin >= 0 && (
             <S.TotalCount>
               <S.CountTitle>총 코인수</S.CountTitle>
               <S.CountNum>{coin}</S.CountNum>

--- a/src/feature/rank/RankFirstInfo/index.stories.jsx
+++ b/src/feature/rank/RankFirstInfo/index.stories.jsx
@@ -9,11 +9,11 @@ export default {
       defaultValue: '',
       control: 'text',
     },
-    coin: {
+    coinCount: {
       defaultValue: '-1',
       control: 'number',
     },
-    TTaBong: {
+    TTaBongCount: {
       defaultValue: '-1',
       control: 'number',
     },

--- a/src/feature/rank/RankFirstInfo/index.stories.jsx
+++ b/src/feature/rank/RankFirstInfo/index.stories.jsx
@@ -10,11 +10,11 @@ export default {
       control: 'text',
     },
     coin: {
-      defaultValue: null,
+      defaultValue: '-1',
       control: 'number',
     },
     TTaBong: {
-      defaultValue: null,
+      defaultValue: '-1',
       control: 'number',
     },
   },

--- a/src/feature/rank/RankFirstInfo/index.stories.jsx
+++ b/src/feature/rank/RankFirstInfo/index.stories.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import RankFirstInfo from '.';
+
+export default {
+  title: 'Feature/rank/RankFirstInfo',
+  component: RankFirstInfo,
+  argTypes: {
+    userName: {
+      defaultValue: '',
+      control: 'text',
+    },
+    coin: {
+      defaultValue: null,
+      control: 'number',
+    },
+    TTaBong: {
+      defaultValue: null,
+      control: 'number',
+    },
+  },
+};
+export const Default = (args) => {
+  return <RankFirstInfo {...args} />;
+};

--- a/src/feature/rank/RankFirstInfo/style.jsx
+++ b/src/feature/rank/RankFirstInfo/style.jsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+
+export const RankFirstContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  gap: 24px;
+`;
+
+export const RankFirstWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  color: ${({ theme }) => theme.colors.yellow[0]};
+  font-family: sans-serif;
+  font-size: 25px;
+  font-weight: 800;
+`;
+
+export const RankFirstInfoWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  gap: 24px;
+`;
+
+export const AvatarBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const InfoBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  gap: 16px;
+`;
+
+export const UserNameWrapper = styled.span`
+  font-family: 'Noto Sans KR';
+  font-weight: 700;
+`;
+
+export const TotalCount = styled.dl`
+  display: flex;
+
+  gap: 8px;
+`;
+
+export const CountTitle = styled.dt`
+  font-size: 13px;
+`;
+
+export const CountNum = styled.dd`
+  font-weight: 600;
+`;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
- 브랜치 명은 `\#44/Feat/RankFirstInfo` 입니다
- 랭크페이지에서 1위 info 컴포넌트입니다.
<img width="237" alt="스크린샷 2022-06-15 오후 3 46 03" src="https://user-images.githubusercontent.com/76620786/173760545-364dda97-31d3-40b3-ac81-97d9d7cece69.png">


### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- props
  - avatarImg => 아바타 이미지
  - userName => 랭크 1위 이름
  - coin => 코인왕 코인 갯수
  - TTaBong => 따봉왕 따봉 갯수
 
구조

- RankFirstContainer
  - RankFirstWrapper => 현재 1위 타이틀
  - RankFirstInfoWrapper => 현재 1위 정보
    - AvatarBox => 아바타 이미지 (추후 디자인 개선이 되면 왕관 넣으면 좋을 거 같습니다)
    - InfoBox
      - UserNameWrapper => 현재 1위 이름
      - TotalCount => CountContainer로 바꿀까요??
        - CountTitle => 코인 or 따봉
        - CountNum => 총 코인(따봉)수 

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
- 역시나 변수명 짓는건 ㅜ.ㅜ

closed #44 