### PR TITLE
Fix/useScroll consistent-return 관련 에러 해결

### DIFF
--- a/src/hooks/useScroll.js
+++ b/src/hooks/useScroll.js
@@ -6,7 +6,7 @@ export const useScroll = () => {
   const ref = useRef(null);
   useEffect(() => {
     const element = ref.current;
-    if (!element) return;
+    if (!element) return null;
 
     const handleScroll = () => {
       setOffset({


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

useScroll 사용시 나타나던 consistent-return 에러 해결

![fixfixfix](https://user-images.githubusercontent.com/97934878/174222936-4243261a-d122-4c5e-a184-c7d3cabc294f.gif)


### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

#### 문제의 원인
문제의 원인은 상황에 따라 return값이 반환되거나 반환되지 않았기 때문이었습니다.

eslint의 consistent-return 규칙에 따르면,
return은 `항상 아무것도 반환하지 않거나`, `늘 어떤 값을 반환하거나(적어도 undefined이라도)`.
이 둘 중 하나의 규칙을 따라야 합니다.

하지만 기존 코드는 이벤트에 따라 
`return이 아무것도 반환되지 않거나`,  `함수로 반환되거나`.
이 두가지 경우가 혼재되어 있었고, 이로 인해 eslint의 consistent-return 에러가 발생하였습니다.

기존 코드
![스크린샷 2022-06-17 오후 1 03 56](https://user-images.githubusercontent.com/97934878/174223256-14ecf1a7-bcf7-4010-855a-63abb5a2a275.png)


#### 문제 해결

상단의 아무것도 반환하지 않는 return에 `null`값을 넣어주었습니다.

수정된 코드
![스크린샷 2022-06-17 오후 1 04 13](https://user-images.githubusercontent.com/97934878/174223532-41f23020-2363-4ddd-b74e-71c06254a343.png)

<br>

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->


- [ ] 적절한 해결방법이었는지 확인 부탁드립니다.
- [ ] 🚨현재 빈 값을 위해 null값을 넣어두긴 했지만, undefined이 더 적합할 것 같다는 생각도 듭니다.
null과 undefined중 어느 것이 더 return값으로 적합할까요? 의견 부탁드립니다!!🚨

<br>
<Br>

### 🚀 연관된 이슈

close #70 