### PR TITLE
Feat/ Rank 페이지 구현

### DIFF
--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -10,12 +10,15 @@ import { getAllUsers, getChannelPosts } from '../../apis/index';
 import { TabItem } from '../../components/Tab';
 
 const RankPage = () => {
+  const TTABONG = 'TTaBongCount';
+  const COIN = 'coinCount';
+
   const [users, setUsers] = useState([
     {
       fullName: undefined,
     },
   ]);
-  const [goods, setGoods] = useState('TTaBongCount');
+  const [goods, setGoods] = useState(TTABONG);
 
   const sortGoods = (goods) => {
     setUsers(
@@ -30,14 +33,9 @@ const RankPage = () => {
     );
   };
 
-  const clickTTaBongKing = () => {
-    setGoods('TTaBongCount');
-    sortGoods('TTaBongCount');
-  };
-
-  const clickCoinKing = () => {
-    setGoods('coinCount');
-    sortGoods('coinCount');
+  const onClickTab = (type) => {
+    setGoods(type);
+    sortGoods(type);
   };
 
   // users = [{id, 이름, 따봉카운트, 코인카운트},...]
@@ -56,7 +54,7 @@ const RankPage = () => {
       for (let i = 0; i < allUserInfo.length; i += 1) {
         const { _id, coinCount } = allUserInfo[i];
         if (receiver === _id) {
-          const count = type === 'TTaBongCount' ? coinCount + 1 : coinCount + 2;
+          const count = type === TTABONG ? coinCount + 1 : coinCount + 2;
           allUserInfo[i].coinCount = count;
           break;
         }
@@ -75,33 +73,32 @@ const RankPage = () => {
     <PageTemplate page="rank">
       <S.RankPageContainer>
         <S.TabContainer>
-          <TabItem active={goods === 'TTaBongCount'} onClick={clickTTaBongKing}>
+          <TabItem
+            active={goods === TTABONG}
+            onClick={() => onClickTab(TTABONG)}
+          >
             따봉왕
           </TabItem>
-          <TabItem active={goods === 'coinCount'} onClick={clickCoinKing}>
+          <TabItem active={goods === COIN} onClick={() => onClickTab(COIN)}>
             코인왕
           </TabItem>
         </S.TabContainer>
         {/* height를 rem으로 줌 */}
-        <BaseCardContainer height={34} opacityType="0.7">
+        <BaseCardContainer height={34} opacityType={0.7}>
           <RankFirstInfo
             userName={users[0].fullName}
-            TTaBongCount={goods === 'TTaBongCount' ? users[0].TTaBongCount : -1}
-            coinCount={goods === 'coinCount' ? users[0].coinCount : -1}
+            TTaBongCount={goods === TTABONG ? users[0][TTABONG] : -1}
+            coinCount={goods === COIN ? users[0][COIN] : -1}
           />
           <S.RankList>
-            {users.map((user, i) => {
-              if (i === 0) return null; // 랭크 1등 null
-
+            {users.slice(1).map((user, i) => {
               return (
                 <UserInfoItem
-                  rank={i + 1}
+                  rank={i + 2}
                   key={user._id}
                   userName={user.fullName}
-                  TTaBongCount={
-                    goods === 'TTaBongCount' ? user.TTaBongCount : -1
-                  }
-                  coinCount={goods === 'coinCount' ? user.coinCount : -1}
+                  TTaBongCount={goods === TTABONG ? user[TTABONG] : -1}
+                  coinCount={goods === COIN ? user[COIN] : -1}
                 />
               );
             })}

--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -53,7 +53,7 @@ const RankPage = () => {
       for (let i = 0; i < allUserInfo.length; i += 1) {
         const { _id, coinCount } = allUserInfo[i];
         if (receiver === _id) {
-          const count = type === TTABONG ? coinCount + 1 : coinCount + 2;
+          const count = type === 'TTaBong' ? coinCount + 1 : coinCount + 2;
           allUserInfo[i].coinCount = count;
           break;
         }

--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -26,8 +26,8 @@ const RankPage = () => {
         if (pre[goods] < cur[goods]) return 1;
         if (pre[goods] > cur[goods]) return -1;
         // 갯수가 같은 경우 id 우선 (먼저 만든 사람 우선)
-        if (pre._id > cur._id) return 1;
-        if (pre._id < cur._id) return -1;
+        if (pre._id < cur._id) return 1;
+        if (pre._id > cur._id) return -1;
         return 0;
       }),
     );

--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -41,8 +41,7 @@ const RankPage = () => {
   // users = [{id, 이름, 따봉카운트, 코인카운트},...]
   const sortUsers = async () => {
     const allUsers = await getAllUsers();
-    const channelPosts = await getChannelPosts('62a19123d1b81239d875d20d');
-
+    const channelPosts = await getChannelPosts('62a19123d1b81239d875d20d'); // @todo 전역에서 test channel id 설정하면 들고와서 다시 설정
     const allUserInfo = allUsers.map(({ fullName, _id, posts }) => {
       return { _id, fullName, TTaBongCount: posts.length, coinCount: 0 };
     });
@@ -83,7 +82,7 @@ const RankPage = () => {
             코인왕
           </TabItem>
         </S.TabContainer>
-        {/* height를 rem으로 줌 */}
+        {/* height를 rem으로 줌 @todo basecardcontainer props 변경으로 바꿔야됨 */}
         <BaseCardContainer height={34} opacityType={0.7}>
           <RankFirstInfo
             userName={users[0].fullName}
@@ -103,7 +102,7 @@ const RankPage = () => {
               );
             })}
           </S.RankList>
-          {/* 사용자가 로그인 했다면 보여줘야함 */}
+          {/* @todo 사용자가 로그인 했다면 보여줘야함 */}
           <S.MyRankWrapper>
             <UserInfoItem rank={5} TTaBongCount={3} userName="사용자" />
           </S.MyRankWrapper>

--- a/src/pages/RankPage/index.stories.jsx
+++ b/src/pages/RankPage/index.stories.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import RankPage from '.';
+
+export default {
+  title: 'pages/RankPage',
+  component: RankPage,
+  argTypes: {},
+};
+export const Default = (args) => {
+  return (
+    <Router>
+      <RankPage {...args} />;
+    </Router>
+  );
+};

--- a/src/pages/RankPage/style.jsx
+++ b/src/pages/RankPage/style.jsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import { getPxToRem } from '../../utils/getPxToRem';
+
+export const RankPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  position: relative;
+
+  height: ${getPxToRem(600)};
+  gap: 16px;
+`;
+
+export const TabContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const RankList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+
+  margin: 16px 0;
+  padding: 8px 0;
+  gap: 8px;
+  max-height: ${getPxToRem(255)};
+`;
+
+export const MyRankWrapper = styled.div`
+  position: absolute;
+  bottom: 16px;
+`;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
Rank 페이지 구현

![Kapture 2022-06-18 at 13 11 57](https://user-images.githubusercontent.com/76620786/174422387-a7c6a33c-fd59-40f2-a385-74e28320be65.gif)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- 컴포넌트 사용 (Page Template, BaseCardContainer, UserInfoItem, RankFirstInfo, TabItem)

- 따봉 갯수 세는 로직: 해당 유저의 포스트 갯수
- 코인 갯수 세는 로직
  - 모든 유저 목록 불러온다 (getAllUser)
  - 채널에 있는 포스트 목록을 불러온다 (getChannelPosts(채널아이디))
  - 각 유저를  {id, fullname, 따봉수, 코인수} 객체로 만들어 배열을 만든다
  - 채널에 있는 포스트 목록을 돌면서 receiver와 유저 id 를 확인해 같은지 확인한다
  - 받는 사람이 정해지면 type에 따라 따봉일 땐 coinCount 1, 빅따봉일 떈 coinCount 2를 올려준다

위와 같이 분류하게 되면 다음과 같은 배열을 rankPage 내에 만들게 된다.
users => [{id, fullName, 따봉 수: 0, 코인 수: 4}, ...] 

- 분류 하는 로직
  - 갯수에 따라 높은 순서로 앞에서 정렬
  - 갯수가 같다면 id 순서대로 정렬 (먼저 만든 사람 우선)

아직 완전하지 않은 기능
- 해당 유저가 로그인 했다면 아래 사용자 랭크를 보여주는 기능 (추후 추가 예정)
 
### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
- 로직 중에 혹시 이해가 안가는 코드 있으면 질문해주세요

### 🚀 연관된 이슈
closed #29 