### PR TITLE
#76/refactor/card to base card container

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import {
   UserProfilePage,
 } from './pages';
 import NotFoundPage from './pages/NotFound';
+import TestApiComponent from './feature/TestApiComponent';
 
 function App() {
   return (
@@ -25,6 +26,7 @@ function App() {
         <Route path="/search/*" element={<SearchPage />} />
         <Route path="/userProfile/*" element={<UserProfilePage />} />
         <Route path="/error/*" element={<NotFoundPage />} />
+        <Route path="/api/*" element={<TestApiComponent />} />
         <Route path="/*" element={<Navigate to="/mainFeed" />} />
       </Routes>
     </ThemeProvider>

--- a/src/components/Avatar/index.jsx
+++ b/src/components/Avatar/index.jsx
@@ -24,9 +24,9 @@ const Avatar = ({
 };
 
 Avatar.propTypes = {
-  size: PropTypes.number.isRequired,
-  src: PropTypes.string.isRequired,
-  avatarName: PropTypes.string.isRequired,
+  size: PropTypes.number,
+  src: PropTypes.string,
+  avatarName: PropTypes.string,
 };
 
 export default Avatar;

--- a/src/components/BaseCardContainer/index.jsx
+++ b/src/components/BaseCardContainer/index.jsx
@@ -7,7 +7,7 @@ const BaseCardContainer = ({
   children,
   width = '100%',
   height = '100%',
-  padding = [2, 1, 2, 1],
+  padding = [2, 1, 0, 1],
   opacityType = theme.opacity.visible,
   backgroundColor = `${theme.colors.white}`,
   borderRadius = `${theme.borderRadius.rounded}`,

--- a/src/components/BaseCardContainer/index.jsx
+++ b/src/components/BaseCardContainer/index.jsx
@@ -11,6 +11,7 @@ const BaseCardContainer = ({
   opacityType = theme.opacity.visible,
   backgroundColor = `${theme.colors.white}`,
   borderRadius = `${theme.borderRadius.rounded}`,
+  overflow,
 }) => {
   return (
     <S.Container
@@ -20,6 +21,7 @@ const BaseCardContainer = ({
       padding={padding}
       backgroundColor={backgroundColor}
       borderRadius={borderRadius}
+      overflow={overflow}
     >
       <S.ContentSection>{children}</S.ContentSection>
     </S.Container>

--- a/src/components/BaseCardContainer/index.stories.jsx
+++ b/src/components/BaseCardContainer/index.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import BaseCardContainer from '.';
-import PageTemplate from '../../pages/PageTemplate';
+import PageTemplate from '../../feature/pageTemplate/PageTemplate';
 import theme from '../../commons/style/themes';
 
 export default {
@@ -44,32 +45,34 @@ export function Default(args) {
 
 export function Template(args) {
   return (
-    <PageTemplate>
-      <BaseCardContainer {...args}>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-        <p>hello world</p>
-      </BaseCardContainer>
-    </PageTemplate>
+    <Router>
+      <PageTemplate>
+        <BaseCardContainer {...args}>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+          <p>hello world</p>
+        </BaseCardContainer>
+      </PageTemplate>
+    </Router>
   );
 }

--- a/src/components/BaseCardContainer/style.jsx
+++ b/src/components/BaseCardContainer/style.jsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 import { getHexToRgb } from '../../utils/getHexToRgb';
+import { getPxToRem } from '../../utils/getPxToRem';
 
 export const Container = styled.div`
-  width: ${({ width }) => (typeof width === 'number' ? `${width}rem` : width)};
+  width: ${({ width }) =>
+    typeof width === 'number' ? `${getPxToRem(width)}` : width};
   height: ${({ height }) =>
-    typeof height === 'number' ? `${height}rem` : height};
+    typeof height === 'number' ? `${getPxToRem(height)}` : height};
 
   padding: ${({ padding }) => padding.map((pad) => `${pad}rem`).join(' ')};
   background-color: ${({ backgroundColor, opacity }) =>
@@ -16,5 +18,5 @@ export const Container = styled.div`
 
 export const ContentSection = styled.div`
   height: 100%;
-  overflow: auto;
+  ${({ overflow }) => `overflow : ${overflow}`}
 `;

--- a/src/components/Logo/index.jsx
+++ b/src/components/Logo/index.jsx
@@ -10,5 +10,5 @@ const Logo = ({ type = 'white', ...props }) => (
 export default Logo;
 
 Logo.propTypes = {
-  type: PropTypes.string.isRequired, // lint적용되면 isRequired 제거
+  type: PropTypes.string, // lint적용되면 isRequired 제거
 };

--- a/src/feature/Cards/MainCard/index.jsx
+++ b/src/feature/Cards/MainCard/index.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
 import * as S from './style';
 import TB from '../../../assets/ttabong_card.svg';
 import likes from '../../../assets/sympathy_ttabong.svg';
@@ -7,6 +8,7 @@ import Avatar from '../../../components/Avatar';
 import TTaBongerAndTTaBonged from '../TTaBongerAndTTaBonged';
 import LabelList from '../LabelList';
 import Divider from '../../../components/Divider';
+import BaseCardContainer from '../../../components/BaseCardContainer';
 
 // 아바타2개 컨테이너 분리
 // 디비전 라인 컴포넌트 분리 -> base 로 분리
@@ -20,31 +22,36 @@ const MainCard = ({
   likeReason = '',
   labelItems = [],
 }) => {
+  const navigate = useNavigate();
+  const handleClick = () => navigate(`/cardDetail/${authorName}`);
+
   // label이 없는경우를 대비해 default는 빈배열로 일단 처리
   return (
-    <S.BackgroundCard>
-      <TTaBongerAndTTaBonged
-        authorName={authorName}
-        receiverName={receiverName}
-      />
-      <Divider size={300} />
-      <S.SecondSection>
-        <S.PraiseContainer>
-          <S.PraiseReason>칭찬사유</S.PraiseReason>
-          <S.PraiseContent>{likeReason}</S.PraiseContent>
-        </S.PraiseContainer>
-        <S.InfoContainer>
-          <LabelList labelItems={labelItems} />
-          <S.LikeContainer>
-            <S.CountNumContainer>
-              <S.CountSpan>댓글 수 {commentCount}개</S.CountSpan>
-              <S.CountSpan>맞 따봉 {likeCount}개</S.CountSpan>
-            </S.CountNumContainer>
-            <img src={likes} alt="공감" width="28px" height="28px" />
-          </S.LikeContainer>
-        </S.InfoContainer>
-      </S.SecondSection>
-    </S.BackgroundCard>
+    <BaseCardContainer width={358} height={204}>
+      <S.MainCardContainer onClick={handleClick}>
+        <TTaBongerAndTTaBonged
+          authorName={authorName}
+          receiverName={receiverName}
+        />
+        <Divider size={300} />
+        <S.SecondSection>
+          <S.PraiseContainer>
+            <S.PraiseReason>칭찬사유</S.PraiseReason>
+            <S.PraiseContent>{likeReason}</S.PraiseContent>
+          </S.PraiseContainer>
+          <S.InfoContainer>
+            <LabelList labelItems={labelItems} />
+            <S.LikeContainer>
+              <S.CountNumContainer>
+                <S.CountSpan>댓글 수 {commentCount}개</S.CountSpan>
+                <S.CountSpan>맞 따봉 {likeCount}개</S.CountSpan>
+              </S.CountNumContainer>
+              <img src={likes} alt="공감" width="28px" height="28px" />
+            </S.LikeContainer>
+          </S.InfoContainer>
+        </S.SecondSection>
+      </S.MainCardContainer>
+    </BaseCardContainer>
   );
 };
 

--- a/src/feature/Cards/MainCard/index.jsx
+++ b/src/feature/Cards/MainCard/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import * as S from './style';
 import TB from '../../../assets/ttabong_card.svg';
-import likes from '../../../assets/sympathy_ttabong.svg';
+import likesLine from '../../../assets/sympathy_ttabong.svg';
 import Label from '../../../components/Label';
 import Avatar from '../../../components/Avatar';
 import TTaBongerAndTTaBonged from '../TTaBongerAndTTaBonged';
@@ -10,43 +10,47 @@ import LabelList from '../LabelList';
 import Divider from '../../../components/Divider';
 import BaseCardContainer from '../../../components/BaseCardContainer';
 
-// 아바타2개 컨테이너 분리
-// 디비전 라인 컴포넌트 분리 -> base 로 분리
-// Card
+const MainCard = ({ post }) => {
+  const {
+    _id: postId,
+    image,
+    imgaePublicId,
+    title,
+    channel,
+    author,
+    likes,
+    comments,
+    createdAt,
+    updatedAt,
+  } = post;
 
-const MainCard = ({
-  authorName = '이름',
-  receiverName = '이름',
-  commentCount = 0,
-  likeCount = 0,
-  likeReason = '',
-  labelItems = [],
-}) => {
+  const { type, receiver, content, labels } = JSON.parse(title.trim());
+
   const navigate = useNavigate();
-  const handleClick = () => navigate(`/cardDetail/${authorName}`);
+  const handleClick = () => navigate(`/cardDetail/${author._id}`);
 
   // label이 없는경우를 대비해 default는 빈배열로 일단 처리
   return (
     <BaseCardContainer width={358} height={204}>
       <S.MainCardContainer onClick={handleClick}>
         <TTaBongerAndTTaBonged
-          authorName={authorName}
-          receiverName={receiverName}
+          authorName={author.fullName}
+          receiverName={receiver.fullName}
         />
         <Divider size={300} />
         <S.SecondSection>
           <S.PraiseContainer>
             <S.PraiseReason>칭찬사유</S.PraiseReason>
-            <S.PraiseContent>{likeReason}</S.PraiseContent>
+            <S.PraiseContent>{content}</S.PraiseContent>
           </S.PraiseContainer>
           <S.InfoContainer>
-            <LabelList labelItems={labelItems} />
+            <LabelList labelItems={labels} />
             <S.LikeContainer>
               <S.CountNumContainer>
-                <S.CountSpan>댓글 수 {commentCount}개</S.CountSpan>
-                <S.CountSpan>맞 따봉 {likeCount}개</S.CountSpan>
+                <S.CountSpan>댓글 수 {comments.length}개</S.CountSpan>
+                <S.CountSpan>맞 따봉 {likes.length}개</S.CountSpan>
               </S.CountNumContainer>
-              <img src={likes} alt="공감" width="28px" height="28px" />
+              <img src={likesLine} alt="공감" width="28px" height="28px" />
             </S.LikeContainer>
           </S.InfoContainer>
         </S.SecondSection>
@@ -55,12 +59,6 @@ const MainCard = ({
   );
 };
 
-MainCard.propTypes = {
-  labelItems: PropTypes.arrayOf(PropTypes.string).isRequired,
-  authorName: PropTypes.string.isRequired,
-  receiverName: PropTypes.string.isRequired,
-  commentCount: PropTypes.number.isRequired,
-  likeCount: PropTypes.number.isRequired,
-};
+MainCard.propTypes = {};
 
 export default MainCard;

--- a/src/feature/Cards/MainCard/index.stories.jsx
+++ b/src/feature/Cards/MainCard/index.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import MainCard from '.';
 
 export default {
@@ -31,5 +32,9 @@ export default {
   },
 };
 export const Default = (args) => {
-  return <MainCard {...args} />;
+  return (
+    <Router>
+      <MainCard {...args} />
+    </Router>
+  );
 };

--- a/src/feature/Cards/MainCard/index.stories.jsx
+++ b/src/feature/Cards/MainCard/index.stories.jsx
@@ -6,28 +6,21 @@ export default {
   title: 'feature/cards/MainCard',
   component: MainCard,
   argTypes: {
-    labelItems: {
-      defaultValue: ['moved', 'praise', 'warm'],
-    },
-    authorName: {
-      defaultValue: '이우제',
-      control: 'text',
-    },
-    receiverName: {
-      defaultValue: '민상기',
-      control: 'text',
-    },
-    commentCount: {
-      defaultValue: '3',
-      control: 'number',
-    },
-    likeCount: {
-      defaultValue: '5',
-      control: 'number',
-    },
-    likeReason: {
-      defaultValue: '열심히 해서',
-      control: 'text',
+    post: {
+      type: { name: 'object' },
+      defaultValue: {
+        _id: '61782364812638741test',
+        image: '',
+        imgaePublicId: '',
+        title:
+          '{"type":"BigTTaBong","receiver":"62a83493cab1ef0259bc53f6","content":"오바마 아주아주아주감사해"}',
+        channel: { _id: 'channelId' },
+        author: { _id: 'userId', fullName: 'authorName', email: 'authorEmail' },
+        likes: ['like1', 'like2'],
+        comments: ['comment1', 'comment2', 'comment3'],
+        createdAt: '',
+        updatedAt: '',
+      },
     },
   },
 };

--- a/src/feature/Cards/MainCard/style.jsx
+++ b/src/feature/Cards/MainCard/style.jsx
@@ -1,12 +1,8 @@
 import styled from '@emotion/styled';
 
-export const BackgroundCard = styled.div`
-  width: 358px;
-  height: 204px;
-  background-color: ${(props) => props.theme.colors.white};
-  border-radius: 30px;
-  padding-top: 16px;
-  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+export const MainCardContainer = styled.div`
+  width: 100%;
+  height: 100%;
 `;
 
 export const SecondSection = styled.section`

--- a/src/feature/TestApiComponent/index.jsx
+++ b/src/feature/TestApiComponent/index.jsx
@@ -17,6 +17,7 @@ import {
   putPost,
   signUp,
 } from '../../apis';
+import MainCard from '../Cards/MainCard';
 
 function TestApiComponent() {
   const [channel, setChannel] = useState({});
@@ -154,8 +155,12 @@ function TestApiComponent() {
 
     const title = JSON.stringify({
       type,
-      receiver: receiver._id,
+      receiver: {
+        _id: receiver._id,
+        fullName: receiver.fullName,
+      },
       content: postInput,
+      labels: ['warm', 'moved'],
     });
 
     const newPost = await await createPost(curUser.token, channel._id, title);
@@ -362,6 +367,7 @@ function TestApiComponent() {
               </button>
             </p>
             {post.title}
+            <MainCard post={post} />
           </p>
         ))}
       </p>

--- a/src/feature/pageTemplate/PageTemplate/style.jsx
+++ b/src/feature/pageTemplate/PageTemplate/style.jsx
@@ -30,5 +30,7 @@ export const ContentSection = styled.div`
   justify-content: center;
   align-items: center;
   margin-top: 74px;
-  line-height: 2rem;
+
+  /* 이것 때문에 카드 밖으로 내용이 뛰쳐 나가서 임시로 주석 처리하였습니다. /*
+  /* line-height: 2rem; */
 `;

--- a/src/pages/MainFeedPage/index.jsx
+++ b/src/pages/MainFeedPage/index.jsx
@@ -8,7 +8,7 @@ import DummyData from '../../assets/data/dummyData';
 import { useScrollDown } from '../../hooks/useScrollDown';
 
 const MainFeedPage = () => {
-  const { Posts, Users } = DummyData;
+  const { Posts } = DummyData;
   const [posts, setPosts] = useState([]);
 
   const [ref, isScrollDown] = useScrollDown();
@@ -25,29 +25,11 @@ const MainFeedPage = () => {
         className={!isScrollDown ? 'bannerShown' : null}
       >
         <Banner isScrollDown={isScrollDown} />
-        {posts.map((post) => {
-          const { likes, comments, title, author } = post;
-          const { type, receiver, content } = JSON.parse(title);
-          const { fullName } = author;
-
-          const receiverName = Users.map((user) => {
-            return user._id === receiver ? user.fullName : null;
-          });
-
-          return (
-            <S.MainCardWrapper>
-              <MainCard
-                authorName={fullName}
-                receiverName={receiverName}
-                commenCount={comments.length}
-                likeCount={likes.length}
-                likeReason={content}
-                // 라벨 타입은 일단 임시로 하드코딩 해 두었습니다...!!
-                labelTypes={['warm', 'moved', 'praise']}
-              />
-            </S.MainCardWrapper>
-          );
-        })}
+        {posts.map((post) => (
+          <S.MainCardWrapper key={post._id}>
+            <MainCard post={post} />
+          </S.MainCardWrapper>
+        ))}
       </S.MainFeedPageContainer>
     </PageTemplate>
   );

--- a/src/pages/MainFeedPage/index.jsx
+++ b/src/pages/MainFeedPage/index.jsx
@@ -35,15 +35,17 @@ const MainFeedPage = () => {
           });
 
           return (
-            <MainCard
-              authorName={fullName}
-              receiverName={receiverName}
-              commenCount={comments.length}
-              likeCount={likes.length}
-              likeReason={content}
-              // 라벨 타입은 일단 임시로 하드코딩 해 두었습니다...!!
-              labelTypes={['warm', 'moved', 'praise']}
-            />
+            <S.MainCardWrapper>
+              <MainCard
+                authorName={fullName}
+                receiverName={receiverName}
+                commenCount={comments.length}
+                likeCount={likes.length}
+                likeReason={content}
+                // 라벨 타입은 일단 임시로 하드코딩 해 두었습니다...!!
+                labelTypes={['warm', 'moved', 'praise']}
+              />
+            </S.MainCardWrapper>
           );
         })}
       </S.MainFeedPageContainer>

--- a/src/pages/MainFeedPage/index.jsx
+++ b/src/pages/MainFeedPage/index.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import * as S from './style';
 import PageTemplate from '../../feature/pageTemplate/PageTemplate';
 import Banner from '../../feature/pageTemplate/Banner';
@@ -36,17 +35,15 @@ const MainFeedPage = () => {
           });
 
           return (
-            <Link to="/cardDetail" className="mainCard">
-              <MainCard
-                authorName={fullName}
-                receiverName={receiverName}
-                commenCount={comments.length}
-                likeCount={likes.length}
-                likeReason={content}
-                // 라벨 타입은 일단 임시로 하드코딩 해 두었습니다...!!
-                labelTypes={['warm', 'moved', 'praise']}
-              />
-            </Link>
+            <MainCard
+              authorName={fullName}
+              receiverName={receiverName}
+              commenCount={comments.length}
+              likeCount={likes.length}
+              likeReason={content}
+              // 라벨 타입은 일단 임시로 하드코딩 해 두었습니다...!!
+              labelTypes={['warm', 'moved', 'praise']}
+            />
           );
         })}
       </S.MainFeedPageContainer>

--- a/src/pages/MainFeedPage/style.jsx
+++ b/src/pages/MainFeedPage/style.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { getPxToRem } from '../../utils/getPxToRem';
 
 export const MainFeedPageContainer = styled.div`
   height: 100%;
@@ -15,4 +16,8 @@ export const MainFeedPageContainer = styled.div`
   &.bannerShown {
     margin-top: 3rem;
   }
+`;
+
+export const MainCardWrapper = styled.div`
+  margin-bottom: ${getPxToRem(18)};
 `;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
<img width="293" alt="image" src="https://user-images.githubusercontent.com/19660039/174440389-211e3a1b-d1ef-45c1-bd96-b5054566adde.png">

- 메인카드 간 간격 구현
- 메인카드 내부 내용이 메인 카드 바깥으로 튀어나가는 것 스타일 정리
- 메인카드가 FeedPage로 부터 데이터를 props로 전달받는 방식을 post 객체 그 자체로 받도록 함

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- [Refactor/Link를 useNavigate로 대체](https://github.com/prgrms-fe-devcourse/FEDC2_TTaBong_Dali/pull/85/commits/d1412b882c6cb503d0b8d717164dfcf915a78b97)
처음에 Link때문인 줄 알고 Link삭제하고 MainCard 내부에 useNavigate로 대체

- [Style/ 카드 밖으로 글 뛰쳐나오던 것 해결](https://github.com/prgrms-fe-devcourse/FEDC2_TTaBong_Dali/pull/85/commits/416f822bbab1614565fdeefe608c02cef2b8e790)
PageTemaplte style의 줄간격 때문에 생기던 일. 삭제하고 문제 해결

- [Refactor/ MainCardWrapper 를 통한 카드 간 간격 구현](https://github.com/prgrms-fe-devcourse/FEDC2_TTaBong_Dali/pull/85/commits/9b5a43fec897f260a08bb22cc38f0979f679d2d0)
메인 카드 간 간격 구현 in MainFeedpage

- [Refactor/MainCard의 입력을 {post}로 변경 및 MainFeedPage 수정](https://github.com/prgrms-fe-devcourse/FEDC2_TTaBong_Dali/pull/85/commits/cb0a805e6c003b9b4c9d3096b2aa967b05583f96)
MainCard가 title, author 등... 데이터를 각각 받는 것이 아니라 post 객체 자체를 받는 것으로 수정.
이에 따른 MainFeedpage도 리팩토링
+ 메인카드 클릭할 경우 cardDetail/authorName 이 아닌 cardDetail/authorId로 라우팅

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

혹시 최적화 안 된 로직이 있는지?
더 추가해야할 데이터 처리가 있는지?

### 🚀 연관된 이슈
close #76 