### PR TITLE
#72/feat/메인피드페이지 api 붙이기 및 무한스크롤 구현시도

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^18.1.0",
     "react-cookie": "^4.1.1",
     "react-dom": "^18.1.0",
+    "react-intersection-observer": "^9.3.3",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/pages/MainFeedPage/index.jsx
+++ b/src/pages/MainFeedPage/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
 import * as S from './style';
 import PageTemplate from '../../feature/pageTemplate/PageTemplate';
 import Banner from '../../feature/pageTemplate/Banner';
@@ -11,22 +12,45 @@ import { useScrollDown } from '../../hooks/useScrollDown';
 const MainFeedPage = () => {
   const { Posts } = DummyData;
   const [posts, setPosts] = useState([]);
+  const [lastPost, setLastPost] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [offset, setOffset] = useState(0);
 
   const [ref, isScrollDown] = useScrollDown();
+  const [last, inView] = useInView();
 
-  const testAPI = async () => {
-    const channelAPI = await getChannelPosts('62a19123d1b81239d875d20d');
-    return channelAPI;
-  };
+  const CHANNEL_ID = '62a19123d1b81239d875d20d';
 
+  // inView값이 변경될 때 마다 작동해야하는 useEffect
+  // 어째서인지 작동이 안되고 있다.....젭알..왜 안되...
   useEffect(() => {
-    const testCall = async () => {
-      const channelAPI = await testAPI();
-      setPosts(channelAPI || Posts);
+    console.log('scroll ended');
+    if (inView) {
+      console.log('scroll is end!');
+    }
+  }, [inView]);
+
+  // 최초 랜더링
+  useEffect(() => {
+    const getPosts = async () => {
+      setLoading(true);
+      console.log('start loading');
+
+      await getChannelPosts(CHANNEL_ID, offset).then((response) => {
+        setPosts(response || Posts);
+        console.log('response : ', response);
+      });
+      // 왜 로딩은 성공적으로 되었는데 post는 제대로 나오지 않는가....
+      console.log('posts : ', posts);
+      console.log('loaded posts successfully');
+
+      setLoading(false);
+      console.log('finish loading');
     };
-    testCall();
+    getPosts();
   }, []);
 
+  // 아래 ==는 되고 ===는 안되어서 일단 ==로 했습니다.
   return (
     <PageTemplate page="mainFeed">
       <S.MainFeedPageContainer
@@ -34,9 +58,16 @@ const MainFeedPage = () => {
         className={!isScrollDown ? 'bannerShown' : null}
       >
         <Banner isScrollDown={isScrollDown} />
-        {posts.map((post) => (
+        {posts.map((post, idx) => (
           <S.MainCardWrapper key={post._id}>
-            <MainCard post={post} />
+            {posts.length - 1 === idx ? (
+              <div>
+                <MainCard post={post} ref={last} />
+                <div>hello</div>
+              </div>
+            ) : (
+              <MainCard post={post} />
+            )}
           </S.MainCardWrapper>
         ))}
       </S.MainFeedPageContainer>

--- a/src/pages/MainFeedPage/index.jsx
+++ b/src/pages/MainFeedPage/index.jsx
@@ -5,6 +5,7 @@ import Banner from '../../feature/pageTemplate/Banner';
 import MainCard from '../../feature/Cards/MainCard';
 
 import DummyData from '../../assets/data/dummyData';
+import { getChannelPosts } from '../../apis/index';
 import { useScrollDown } from '../../hooks/useScrollDown';
 
 const MainFeedPage = () => {
@@ -13,9 +14,17 @@ const MainFeedPage = () => {
 
   const [ref, isScrollDown] = useScrollDown();
 
-  // 후에 axios를 통해 Channel을 거쳐 post를 받아오는 작업 필요.
+  const testAPI = async () => {
+    const channelAPI = await getChannelPosts('62a19123d1b81239d875d20d');
+    return channelAPI;
+  };
+
   useEffect(() => {
-    setPosts(Posts);
+    const testCall = async () => {
+      const channelAPI = await testAPI();
+      setPosts(channelAPI || Posts);
+    };
+    testCall();
   }, []);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -12070,6 +12070,11 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
+react-intersection-observer@^9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.3.3.tgz#1266fad4c09d8380462548b71bbc73e0e1c0c089"
+  integrity sha512-IEXX+Qd3/Bi2EzR2TYBLosHIaIMOTpgKRp5UH//eWOuteO/lpyTpQXt5ACy/ZugI6v0nwJBfiKLvWtCaKiRI7g==
+
 react-is@17.0.2, react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

#### 메인 피드 페이지 api 구현 및 무한스크롤 구현 시도

![mainfeedpageapi](https://user-images.githubusercontent.com/97934878/174489655-6ea287f8-67b9-4bcf-91fc-01332ccefc5c.gif)

<br>

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- [ ] 메인피드페이지에 api 데이터를 받을 수 있도록 하였습니다.
- [ ] api가 정상적으로 불러오지 않으면 더미데이터를 불러오도록 하였습니다.
- [ ] useInview를 통해 무한스크롤 구현을 시도하였습니다.

<Br>

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

현재 메인피드페이지를 너무 끌고 있는 느낌이라 일단 PR을 올렸습니다 ㅜ
api까지는 문제없이 붙였는데,
무한 스크롤을 구현하는데 원인을 알 수 없는 에러로 인해 도저히 나아지지 않고 있는 상황입니다...
useInview 라이브러리를 사용하고 있는데
해당 훅이 화면에 지정한 컴포넌트가 들어오는 것을 정상적으로 인지하지 못하고 있는 것 같습니다.
혹시 문제의 원인이나 해결방안을 아시는 분은 도움 부탁드립니다 ㅜㅠ

cf. 가장 마지막 카드 밑에 위치한 hello는 테스트를 위한 요소 입니다. (머지시 삭제 예정)
<br>

### 🚀 연관된 이슈

close #72 

<br>