### PR TITLE
#88/Feat/Context API를 통한 User 정보 전역상태관리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,23 +14,26 @@ import {
   RegisterPage,
 } from './pages';
 import NotFoundPage from './pages/NotFound';
+import UserProvider from './contexts/UserProvider';
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <Routes>
-        <Route path="/mainFeed/*" element={<MainFeedPage />} />
-        <Route path="/cardDetail/*" element={<CardDetailPage />} />
-        <Route path="/rank/*" element={<RankPage />} />
-        <Route path="/TTaBong/*" element={<TTaBongPage />} />
-        <Route path="/search/*" element={<SearchPage />} />
-        <Route path="/userProfile/*" element={<UserProfilePage />} />
-        <Route path="login" element={<LoginPage />} />
-        <Route path="register" element={<RegisterPage />} />
-        <Route path="/error/*" element={<NotFoundPage />} />
-        <Route path="/*" element={<Navigate to="/mainFeed" />} />
-      </Routes>
+      <UserProvider>
+        <Routes>
+          <Route path="/mainFeed/*" element={<MainFeedPage />} />
+          <Route path="/cardDetail/*" element={<CardDetailPage />} />
+          <Route path="/rank/*" element={<RankPage />} />
+          <Route path="/TTaBong/*" element={<TTaBongPage />} />
+          <Route path="/search/*" element={<SearchPage />} />
+          <Route path="/userProfile/*" element={<UserProfilePage />} />
+          <Route path="login" element={<LoginPage />} />
+          <Route path="register" element={<RegisterPage />} />
+          <Route path="/error/*" element={<NotFoundPage />} />
+          <Route path="/*" element={<Navigate to="/mainFeed" />} />
+        </Routes>
+      </UserProvider>
     </ThemeProvider>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import {
 } from './pages';
 import NotFoundPage from './pages/NotFound';
 import UserProvider from './contexts/UserProvider';
+import { AuthRoute, ProtectedRoute } from './routes';
 
 function App() {
   return (
@@ -25,11 +26,17 @@ function App() {
           <Route path="/mainFeed/*" element={<MainFeedPage />} />
           <Route path="/cardDetail/*" element={<CardDetailPage />} />
           <Route path="/rank/*" element={<RankPage />} />
-          <Route path="/TTaBong/*" element={<TTaBongPage />} />
+          <Route
+            path="/TTaBong/*"
+            element={<ProtectedRoute Component={TTaBongPage} />}
+          />
           <Route path="/search/*" element={<SearchPage />} />
           <Route path="/userProfile/*" element={<UserProfilePage />} />
-          <Route path="login" element={<LoginPage />} />
-          <Route path="register" element={<RegisterPage />} />
+          <Route path="/login" element={<AuthRoute Component={LoginPage} />} />
+          <Route
+            path="/register"
+            element={<AuthRoute Component={RegisterPage} />}
+          />
           <Route path="/error/*" element={<NotFoundPage />} />
           <Route path="/*" element={<Navigate to="/mainFeed" />} />
         </Routes>

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -1,7 +1,5 @@
-// import Proptypes from 'prop-types';
 import apiClient from './api';
 import { LOGIN, SIGNUP, LOGOUT } from '../commons/constants/apis';
-import { setCookie } from '../utils/cookies';
 
 // 사용자가 이메일과 비밀번호로 서비스에 로그인합니다.
 export const loginUser = async (email, password) => {
@@ -9,20 +7,9 @@ export const loginUser = async (email, password) => {
     email,
     password,
   });
-  console.log({ user, token });
-
-  setCookie('userToken', token, {
-    path: '/',
-    maxAge: 60 * 60 * 9, // 9시간
-  });
 
   return { user, token };
 };
-
-// logIn.propTypes = {
-//   email: Proptypes.string.isRequired,
-//   password: Proptypes.string.isRequired,
-// };
 
 // 사용자가 이메일과 비밀번호로 서비스에 가입합니다.
 export const registerUser = async (email, fullName, password) => {
@@ -31,16 +18,9 @@ export const registerUser = async (email, fullName, password) => {
     fullName,
     password,
   });
-  console.log({ user, token });
 
   return { user, token };
 };
-
-// signUp.propTypes = {
-//   email: Proptypes.string.isRequired,
-//   fullName: Proptypes.string.isRequired,
-//   password: Proptypes.string.isRequired,
-// };
 
 // 사용자가 로그아웃 합니다.
 // TO BE IMPLEMENTED : 뭘 구현해야 할 지 모르겠음
@@ -58,7 +38,3 @@ export const checkIsAuthUser = async (JWTtoken) => {
 
   return user;
 };
-
-// getAuthUser.propTypes = {
-//   JWTtoken: Proptypes.string.isRequired,
-// };

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -18,7 +18,6 @@ export const registerUser = async (email, fullName, password) => {
     fullName,
     password,
   });
-  // console.log(user, token);
 
   return { user, token };
 };

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -18,6 +18,7 @@ export const registerUser = async (email, fullName, password) => {
     fullName,
     password,
   });
+  // console.log(user, token);
 
   return { user, token };
 };

--- a/src/contexts/UserProvider.jsx
+++ b/src/contexts/UserProvider.jsx
@@ -14,6 +14,7 @@ export const useAuthContext = () => useContext(UserContext);
 const initialUserState = {
   isAuth: false,
   userName: '',
+  userId: '',
   token: '',
 };
 
@@ -23,18 +24,21 @@ const userReducer = (_, action) => {
       return {
         isAuth: action.isAuth,
         userName: action.userName,
+        userId: action.userId,
         token: action.token,
       };
     case 'LOGIN_USER':
       return {
         isAuth: true,
         userName: action.userName,
+        userId: '',
         token: action.token,
       };
     case 'LOGOUT_USER':
       return {
         isAuth: false,
         userName: '',
+        userId: '',
         token: '',
       };
     default:
@@ -46,10 +50,12 @@ const UserProvider = ({ children }) => {
   const [user, dispatch] = useReducer(userReducer, initialUserState);
 
   useEffect(() => {
-    const { userName, token } = getCookie('user') || initialUserState;
+    const { userName, userId, token } = getCookie('user') || initialUserState;
+    console.log(getCookie('user'));
     dispatch({
       type: 'CHECK_USER',
       isAuth: !!token,
+      userId,
       userName,
       token,
     });

--- a/src/contexts/UserProvider.jsx
+++ b/src/contexts/UserProvider.jsx
@@ -47,7 +47,12 @@ const UserProvider = ({ children }) => {
 
   useEffect(() => {
     const { userName, token } = getCookie('user') || initialUserState;
-    dispatch({ type: 'CHECK_USER', isAuth: true, userName, token });
+    dispatch({
+      type: 'CHECK_USER',
+      isAuth: !!token,
+      userName,
+      token,
+    });
   }, []);
 
   const UserContextProviderValue = useMemo(

--- a/src/contexts/UserProvider.jsx
+++ b/src/contexts/UserProvider.jsx
@@ -1,0 +1,65 @@
+import {
+  useMemo,
+  createContext,
+  useContext,
+  useReducer,
+  useEffect,
+} from 'react';
+
+import { getCookie } from '../utils/cookies';
+
+const UserContext = createContext();
+export const useAuthContext = () => useContext(UserContext);
+
+const initialUserState = {
+  isAuth: false,
+  userName: '',
+  token: '',
+};
+
+const userReducer = (_, action) => {
+  switch (action.type) {
+    case 'CHECK_USER':
+      return {
+        isAuth: action.isAuth,
+        userName: action.userName,
+        token: action.token,
+      };
+    case 'LOGIN_USER':
+      return {
+        isAuth: true,
+        userName: action.userName,
+        token: action.token,
+      };
+    case 'LOGOUT_USER':
+      return {
+        isAuth: false,
+        userName: '',
+        token: '',
+      };
+    default:
+      throw new Error('Error');
+  }
+};
+
+const UserProvider = ({ children }) => {
+  const [user, dispatch] = useReducer(userReducer, initialUserState);
+
+  useEffect(() => {
+    const { userName, token } = getCookie('user') || initialUserState;
+    dispatch({ type: 'CHECK_USER', isAuth: true, userName, token });
+  }, []);
+
+  const UserContextProviderValue = useMemo(
+    () => ({ user, dispatch }),
+    [user, dispatch],
+  );
+
+  return (
+    <UserContext.Provider value={UserContextProviderValue}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export default UserProvider;

--- a/src/contexts/UserProvider.jsx
+++ b/src/contexts/UserProvider.jsx
@@ -51,7 +51,7 @@ const UserProvider = ({ children }) => {
 
   useEffect(() => {
     const { userName, userId, token } = getCookie('user') || initialUserState;
-    console.log(getCookie('user'));
+
     dispatch({
       type: 'CHECK_USER',
       isAuth: !!token,

--- a/src/pages/LoginPage/index.jsx
+++ b/src/pages/LoginPage/index.jsx
@@ -7,6 +7,7 @@ import { useAuthContext } from '../../contexts/UserProvider';
 
 const LoginPage = () => {
   const { dispatch } = useAuthContext();
+  const navigate = useNavigate();
 
   const handleLogin = async (email, password) => {
     const { user, token } = await loginUser(email, password);
@@ -22,7 +23,9 @@ const LoginPage = () => {
       },
     );
 
-    // 라우팅
+    if (token) {
+      navigate(-1, { replace: true }); // registerPage에서 오면 ..?
+    }
   };
 
   return (

--- a/src/pages/LoginPage/index.jsx
+++ b/src/pages/LoginPage/index.jsx
@@ -1,13 +1,34 @@
-import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as S from './style';
 import LoginForm from '../../feature/auth/LoginForm';
 import { loginUser } from '../../apis/auth';
+import { setCookie } from '../../utils/cookies';
+import { useAuthContext } from '../../contexts/UserProvider';
 
 const LoginPage = () => {
+  const { dispatch } = useAuthContext();
+
+  const handleLogin = async (email, password) => {
+    const { user, token } = await loginUser(email, password);
+
+    await dispatch({ type: 'LOGIN_USER', userName: user.fullName, token });
+
+    setCookie(
+      'user',
+      { userName: user.fullName, token },
+      {
+        path: '/',
+        maxAge: 60 * 60 * 9, // 9시간
+      },
+    );
+
+    // 라우팅
+  };
+
   return (
     <S.LoginPageWrapper>
       <S.PlacedLogo type="skyblue" />
-      <LoginForm onSubmit={loginUser} />
+      <LoginForm onSubmit={handleLogin} />
     </S.LoginPageWrapper>
   );
 };

--- a/src/pages/LoginPage/index.jsx
+++ b/src/pages/LoginPage/index.jsx
@@ -12,11 +12,16 @@ const LoginPage = () => {
   const handleLogin = async (email, password) => {
     const { user, token } = await loginUser(email, password);
 
-    await dispatch({ type: 'LOGIN_USER', userName: user.fullName, token });
+    await dispatch({
+      type: 'LOGIN_USER',
+      userName: user.fullName,
+      userId: user._id,
+      token,
+    });
 
     setCookie(
       'user',
-      { userName: user.fullName, token },
+      { userName: user.fullName, userId: user._id, token },
       {
         path: '/',
         maxAge: 60 * 60 * 9, // 9시간

--- a/src/pages/RegisterPage/index.jsx
+++ b/src/pages/RegisterPage/index.jsx
@@ -1,13 +1,24 @@
-import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as S from './style';
 import RegisterForm from '../../feature/auth/RegisterForm';
 import { registerUser } from '../../apis/auth';
 
 const RegisterPage = () => {
+  const navigate = useNavigate();
+
+  const handleRegister = async (email, fullName, password) => {
+    const { token } = await registerUser(email, fullName, password);
+
+    if (token) {
+      alert('회원가입이 성공적으로 완료되었습니다.');
+      navigate('/login');
+    }
+  };
+
   return (
     <S.RegisterPageWrapper>
       <S.PlacedLogo type="skyblue" />
-      <RegisterForm onSubmit={registerUser} />
+      <RegisterForm onSubmit={handleRegister} />
     </S.RegisterPageWrapper>
   );
 };

--- a/src/routes/AuthRoute.jsx
+++ b/src/routes/AuthRoute.jsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthContext } from '../contexts/UserProvider';
+
+const AuthRoute = ({ Component }) => {
+  const { user } = useAuthContext();
+
+  return user.isAuth ? <Navigate to="/" /> : <Component />;
+};
+
+export default AuthRoute;

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,11 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthContext } from '../contexts/UserProvider';
+
+const ProtectedRoute = ({ Component }) => {
+  const { user } = useAuthContext();
+  console.log(user.isAuth);
+
+  return user.isAuth ? <Component /> : <Navigate to="/login" />;
+};
+
+export default ProtectedRoute;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,2 @@
+export { default as AuthRoute } from './AuthRoute';
+export { default as ProtectedRoute } from './ProtectedRoute';


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
- [x] auth 상태 전역으로 관리 및 유지
- [x] AuthRoute, ProtectedRoute 생성 ([참고](https://dev.to/nilanth/how-to-create-public-and-private-routes-using-react-router-72m))

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
### Context API를 활용한 auth 상태 전역 관리 및 유지
![image](https://user-images.githubusercontent.com/50645183/174523192-aa95d535-959e-41e6-ab6c-90abdef2b9b0.png)
```jsx
user = {
  isAuth: false,
  userName: '',
  userId: '',
  token: '',
}
```
위와 같이 ```userProvider```를 사용해 ```user``` 데이터를 전역으로 사용하고 상태 업데이트를 할 수 있도록 ```dispatch```를 구현했습니다.

![image](https://user-images.githubusercontent.com/50645183/174523796-c810b802-8f1a-4bb7-8d2d-ec6c8501eacf.png)
-```useAuthContext```를 활용해 필요한 곳에서 사용하시면 됩니다. 아마 ```isAuth, token``` 등이 필요하실 겁니다.
- 전역 상태인 user를 사용하기 위해서는 아래와 같이 사용하시면 됩니다.
```jsx
import { useAuthContext } from '../contexts/UserProvider';

const { user } = useAuthContext();

console.log(user.isAuth, user.token)
```

* * * 

###  AuthRoute, ProtectedRoute 생성
- ```AuthRoute```: isAuth가 true일 때 접근하지 못하는 Route, 반대의 경우 MainPage로 라우팅 처리됨
- ```ProtectedRoute```: isAuth가 true일 때만  접근 가능한 Route, 반대의 경우 LoginPage로 라우팅 처리됨
- 사용법은 ```App.js```를 참고하시면 됩니다.
(PublicRoute는 딱히 처리해줄 필요가 저희 서비스에서는 없는 것 같아 원래 Route를 사용하면 될 것 같습니다.)

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
- 토큰 사용 때문에 빠른 Merge가 필요하지 않을까 싶습니다.
- 궁금한 점 있으면 말씀해주세요!

### 🚀 연관된 이슈
resolved #88