### PR TITLE
Feat/ 칭찬 사유 컴포넌트 구현

### DIFF
--- a/src/feature/ttabong/ReasonContainer/index.jsx
+++ b/src/feature/ttabong/ReasonContainer/index.jsx
@@ -1,0 +1,11 @@
+import * as S from './style';
+
+const ReasonContainer = () => {
+  const onChangeText = (event) => {
+    // event.target.value를 상위 컴포넌트(칭찬하기 페이지로 보내면 될듯합니다)
+  };
+
+  return <S.StyledTextarea placeholder="따봉 사유" onChange={onChangeText} />;
+};
+
+export default ReasonContainer;

--- a/src/feature/ttabong/ReasonContainer/index.stories.jsx
+++ b/src/feature/ttabong/ReasonContainer/index.stories.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReasonContainer from '.';
+
+export default {
+  title: 'feature/ttabong/ReasonContainer',
+  component: ReasonContainer,
+  argTypes: {},
+};
+export const Default = (args) => {
+  return <ReasonContainer {...args} />;
+};

--- a/src/feature/ttabong/ReasonContainer/style.jsx
+++ b/src/feature/ttabong/ReasonContainer/style.jsx
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+import { getPxToRem } from '../../../utils/getPxToRem';
+
+export const StyledTextarea = styled.textarea`
+  width: 100%;
+  height: ${getPxToRem(150)};
+
+  padding: 8px;
+  border: 2px solid ${({ theme }) => theme.colors.yellow[0]};
+  border-radius: 8px;
+  resize: none;
+`;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
`feature/ttabong/ReasonContainer`
칭찬 사유 컴포넌트
<img width="380" alt="스크린샷 2022-06-20 오후 1 50 38" src="https://user-images.githubusercontent.com/76620786/174527658-3e6346f5-fe28-42c1-ace3-52785a4dcd5a.png">
<img width="383" alt="스크린샷 2022-06-20 오후 1 50 30" src="https://user-images.githubusercontent.com/76620786/174527678-d87a99c9-3cc4-4143-822d-79b4deb138d6.png">


### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- textarea로 간단하게 만들었습니다

아직 못 만든 기능
- textarea에 적힌 value를 상위로 보내는 건 따봉페이지 만들 때 구현하겠습니다
### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈
close #98 