### PR TITLE
Refactor/ 랭크페이지 최종

### DIFF
--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -4,7 +4,7 @@ import apiClient from './api';
 const USERS = `/users`;
 
 // 사용자 목록을 불러옵니다.
-export const getAllUsers = async (offset = 0, limit = 10) => {
+export const getAllUsers = async (offset = 0, limit = 100) => {
   const allUsers = await apiClient.get(
     `${USERS}/get-users?offset=${offset}&limit=${limit}`,
   );

--- a/src/commons/constants/index.js
+++ b/src/commons/constants/index.js
@@ -5,6 +5,7 @@ const LabelGood = 'LabelGood';
 const LabelThanks = 'LabelThank';
 
 const CHANNE_NAME = 'Test';
+const TEST_CHANNEL_ID = '62a19123d1b81239d875d20d';
 
 const Constants = {
   TTaBong,
@@ -14,6 +15,7 @@ const Constants = {
   LabelThanks,
 
   CHANNE_NAME,
+  TEST_CHANNEL_ID,
 };
 
 export default Constants;

--- a/src/feature/rank/RankFirstInfo/index.jsx
+++ b/src/feature/rank/RankFirstInfo/index.jsx
@@ -38,7 +38,7 @@ const RankFirstInfo = ({
 
 RankFirstInfo.propTypes = {
   avatarImg: PropTypes.string,
-  userName: PropTypes.string.isRequired,
+  userName: PropTypes.string,
   coinCount: PropTypes.number,
   TTaBongCount: PropTypes.number,
 };

--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -8,11 +8,11 @@ import BaseCardContainer from '../../components/BaseCardContainer';
 import RankFirstInfo from '../../feature/rank/RankFirstInfo';
 import { getAllUsers, getChannelPosts } from '../../apis/index';
 import { TabItem } from '../../components/Tab';
+import Constants from '../../commons/constants/index';
 
 const RankPage = () => {
   const TTABONG = 'TTaBongCount';
   const COIN = 'coinCount';
-  const TEST_CHANNEL_ID = '62a19123d1b81239d875d20d';
 
   const [users, setUsers] = useState([
     {
@@ -42,7 +42,7 @@ const RankPage = () => {
   // users = [{id, 이름, 따봉카운트, 코인카운트},...]
   const sortUsers = async () => {
     const allUsers = await getAllUsers();
-    const channelPosts = await getChannelPosts(TEST_CHANNEL_ID); // @todo 전역에서 test channel id 설정하면 들고와서 다시 설정
+    const channelPosts = await getChannelPosts(Constants.TEST_CHANNEL_ID); // @todo 전역에서 test channel id 설정하면 들고와서 다시 설정
     const allUserInfo = allUsers.map(({ fullName, _id, posts }) => {
       return { _id, fullName, TTaBongCount: posts.length, coinCount: 0 };
     });

--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -1,6 +1,4 @@
 import React, { useState, useEffect } from 'react';
-// import PropTypes from 'prop-types';
-// import { Link } from 'react-router-dom';
 import * as S from './style';
 import PageTemplate from '../../feature/pageTemplate/PageTemplate';
 import UserInfoItem from '../../components/UserInfoItem';
@@ -23,13 +21,17 @@ const RankPage = () => {
 
   const sortGoods = (goods, res = users) => {
     setUsers(
-      res.sort((pre, cur) => {
-        if (pre[goods] < cur[goods]) return 1;
-        if (pre[goods] > cur[goods]) return -1;
-        if (pre._id > cur._id) return 1;
-        if (pre._id < cur._id) return -1;
-        return 0;
-      }),
+      res
+        .sort((pre, cur) => {
+          if (pre[goods] < cur[goods]) return 1;
+          if (pre[goods] > cur[goods]) return -1;
+          if (pre._id > cur._id) return 1;
+          if (pre._id < cur._id) return -1;
+          return 0;
+        })
+        .map((user, i) => {
+          return { ...user, rank: i + 1 };
+        }),
     );
   };
 
@@ -89,10 +91,10 @@ const RankPage = () => {
             coinCount={goods === COIN ? users[0][COIN] : -1}
           />
           <S.RankList>
-            {users.slice(1).map((user, i) => {
+            {users.slice(1).map((user) => {
               return (
                 <UserInfoItem
-                  rank={i + 2}
+                  rank={user.rank}
                   key={user._id}
                   userName={user.fullName}
                   TTaBongCount={goods === TTABONG ? user[TTABONG] : -1}

--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -16,14 +16,14 @@ const RankPage = () => {
 
   const [users, setUsers] = useState([
     {
-      fullName: undefined,
+      fullName: '',
     },
   ]);
   const [goods, setGoods] = useState(TTABONG);
 
-  const sortGoods = (goods) => {
+  const sortGoods = (goods, res = users) => {
     setUsers(
-      users.sort((pre, cur) => {
+      res.sort((pre, cur) => {
         if (pre[goods] < cur[goods]) return 1;
         if (pre[goods] > cur[goods]) return -1;
         if (pre._id > cur._id) return 1;
@@ -38,10 +38,9 @@ const RankPage = () => {
     sortGoods(type);
   };
 
-  // users = [{id, 이름, 따봉카운트, 코인카운트},...]
   const sortUsers = async () => {
     const allUsers = await getAllUsers();
-    const channelPosts = await getChannelPosts(Constants.TEST_CHANNEL_ID); // @todo 전역에서 test channel id 설정하면 들고와서 다시 설정
+    const channelPosts = await getChannelPosts(Constants.TEST_CHANNEL_ID);
     const allUserInfo = allUsers.map(({ fullName, _id, posts }) => {
       return { _id, fullName, TTaBongCount: posts.length, coinCount: 0 };
     });
@@ -49,7 +48,6 @@ const RankPage = () => {
     channelPosts.forEach(({ title }) => {
       const { type, receiver } = JSON.parse(title);
 
-      // 아이디와 receiver가 같다면 해당 id 가진 객체에서 coinCount를 올려준다.
       for (let i = 0; i < allUserInfo.length; i += 1) {
         const { _id, coinCount } = allUserInfo[i];
         if (receiver === _id) {
@@ -59,13 +57,15 @@ const RankPage = () => {
         }
       }
     });
-    setUsers(allUserInfo);
+    return allUserInfo;
   };
 
-  // 마운트 할 때는 따봉왕 정렬
   useEffect(() => {
-    sortUsers();
-    sortGoods(goods);
+    const fetchData = async () => {
+      const sortedUsers = await sortUsers();
+      sortGoods(goods, sortedUsers);
+    };
+    fetchData();
   }, []);
 
   return (

--- a/src/pages/RankPage/index.jsx
+++ b/src/pages/RankPage/index.jsx
@@ -26,9 +26,8 @@ const RankPage = () => {
       users.sort((pre, cur) => {
         if (pre[goods] < cur[goods]) return 1;
         if (pre[goods] > cur[goods]) return -1;
-        // 갯수가 같은 경우 id 우선 (먼저 만든 사람 우선)
-        if (pre._id < cur._id) return 1;
-        if (pre._id > cur._id) return -1;
+        if (pre._id > cur._id) return 1;
+        if (pre._id < cur._id) return -1;
         return 0;
       }),
     );

--- a/src/pages/RankPage/style.jsx
+++ b/src/pages/RankPage/style.jsx
@@ -27,7 +27,8 @@ export const RankList = styled.ul`
   margin: 16px 0;
   padding: 8px 0;
   gap: 8px;
-  max-height: ${getPxToRem(255)};
+  max-height: ${({ isAuth }) =>
+    isAuth ? `${getPxToRem(260)}` : `${getPxToRem(320)}`};
 `;
 
 export const MyRankWrapper = styled.div`


### PR DESCRIPTION
### 📌 설명

랭크 페이지 최종입니다!

로그인 하지 않을 때
![스크린샷 2022-06-20 오후 8 10 05](https://user-images.githubusercontent.com/76620786/174589969-671c5598-664b-41ed-b6cb-c73a1cac3982.png)
로그인 했을 때
![스크린샷 2022-06-20 오후 8 10 28](https://user-images.githubusercontent.com/76620786/174590064-0b4550d6-80e0-4450-b84a-dbb71dc87974.png)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- 총 유저 불러오는 api limit 10에서 100으로 늘렸습니다
- 마운트시 정렬안되는 버그 수정 (useEffect 비동기 문제 해결)
- 로그인 여부에 따라 rankList height 변경

주의할 점
- contextProvider 변수명 user에서 authUser로 변경하므로 이미 수정 상태 (브랜치 pull 하셔서 yarn start 해도 현재는 실행 안될 거에요)

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈
close #108 