### PR TITLE
Feat/MainCard Navigate 로직 수정

### DIFF
--- a/src/feature/Cards/MainCard/index.jsx
+++ b/src/feature/Cards/MainCard/index.jsx
@@ -27,7 +27,7 @@ const MainCard = ({ post }) => {
   const { type, receiver, content, labelItems } = JSON.parse(title.trim());
 
   const navigate = useNavigate();
-  const handleClick = () => navigate(`/cardDetail/${author._id}`);
+  const handleClick = () => navigate(`/cardDetail/${postId}`);
 
   // label이 없는경우를 대비해 default는 빈배열로 일단 처리
   return (


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

MainFeedPage에서 CardDetailPage로 이동할 때
정상적으로 postId를 전달하지 못하던 문제를 해결하였습니다.

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

기존에 author.id로 들어가 있던 값을 postId로 변경

![image](https://user-images.githubusercontent.com/97934878/174723910-e472003b-e191-41b0-b15d-9c46c33cf037.png)



### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈