### PR TITLE
#125/fix/바텀바 링크 관련 버그 해결

### DIFF
--- a/src/feature/pageTemplate/BottomBar/index.jsx
+++ b/src/feature/pageTemplate/BottomBar/index.jsx
@@ -9,7 +9,7 @@ const BottomBar = ({ page }) => {
   return (
     <S.BottomBarContainer>
       <S.IconContainer>
-        <Link to="/main">
+        <Link to="/">
           <Icon
             name={page === 'mainFeed' ? 'listFill' : 'listLine'}
             alt="리스트 아이콘"

--- a/src/pages/AlarmPage/index.jsx
+++ b/src/pages/AlarmPage/index.jsx
@@ -5,7 +5,7 @@ import PageTemplate from '../../feature/pageTemplate/PageTemplate';
 import BaseCardContainer from '../../components/BaseCardContainer';
 import AlarmSection from '../../feature/alarm/AlarmSection';
 import { getNotifications } from '../../apis';
-import NotFoundPage from '../NotFound';
+import NotFoundPage from '../NotFoundPage';
 
 const AlarmPage = () => {
   // 로그인이 되었는지 먼저 확인


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

바텀바의 메인피드페이지 링크가 `/`가 아닌 `/main`으로 가던 문제 해결

<br>

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- [x] 바텀바의 메인피드페이지 링크가 `/`가 아닌 `/main`으로 가던 문제 해결
- [ ] alarmpage의 notfound 폴더명 문제 해결
(이건 윤성님 PR에서 다시한번 더 올려 주신다고 합니다!)

<Br>

### 🚀 연관된 이슈

close #125 

<br>