### PR TITLE
Feat/ Profile Edit 페이지에 프로필 이미지 편집 추가

### DIFF
--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -32,27 +32,15 @@ getSpecificUser.propTypes = {
 
 // TE BOE IMPLEMENTED
 // 나의 프로필 이미지를 변경합니다.
-export const postProfileImg = async (
-  JWTtoken = '',
-  isCover = false,
-  image = '',
-) => {
-  try {
-    const profileImg = await apiClient.post(`${USERS}/upload-photo`, {
-      headers: {
-        Authorization: `bearer ${JWTtoken}`,
-      },
-      isCover,
-      image,
-    });
+export const postProfileImg = async (JWTtoken, formData) => {
+  const profileImg = await apiClient.post(`${USERS}/upload-photo`, formData, {
+    headers: {
+      Authorization: `bearer ${JWTtoken}`,
+      'Content-Type': 'multipart/form-data',
+    },
+  });
 
-    if (profileImg.statusText === 'OK') {
-      return profileImg;
-    }
-  } catch (e) {
-    console.error(e);
-  }
-  return null;
+  return profileImg;
 };
 
 postProfileImg.propTypes = {

--- a/src/feature/profile/ProfileEditForm/index.jsx
+++ b/src/feature/profile/ProfileEditForm/index.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import * as S from './style';
 import useForm from '../../../hooks/useForm';
 import { useAuthContext } from '../../../contexts/UserProvider';
@@ -7,9 +8,11 @@ import {
   PASSWORDCONFIRM_ISNILL_ERROR,
   PASSWORD_UNEQUAL_ERROR,
 } from '../../../commons/constants/error';
+import ImageUploadContainer from '../../ttabong/ImageUploadContainer';
 
 const ProfileEditForm = ({ onSubmit, ...styles }) => {
   const { authUser } = useAuthContext();
+  const [profileImgSrc, setProfileImgSrc] = useState('');
 
   const { isLoading, errors, handleChange, handleSubmit, removeAll } = useForm({
     initialValues: {
@@ -18,7 +21,8 @@ const ProfileEditForm = ({ onSubmit, ...styles }) => {
       passwordConfirm: '',
     },
     onSubmit: async ({ password }) => {
-      await onSubmit(authUser.token, password);
+      console.log(profileImgSrc);
+      await onSubmit(authUser.token, password, profileImgSrc);
     },
     validate: ({ password, passwordConfirm }) => {
       const errors = {};
@@ -66,6 +70,7 @@ const ProfileEditForm = ({ onSubmit, ...styles }) => {
             errors={errors}
             removeAll={removeAll}
           />
+          <ImageUploadContainer setImageSrc={setProfileImgSrc} />
           <S.ProfileEditButton type="submit">프로필 변경</S.ProfileEditButton>
         </S.CenterWrapper>
       </S.ProfileEditForm>

--- a/src/feature/profile/ProfileEditForm/style.jsx
+++ b/src/feature/profile/ProfileEditForm/style.jsx
@@ -29,6 +29,6 @@ export const EditInput = styled(InputForm)`
 `;
 
 export const ProfileEditButton = styled(Button)`
-  margin-top: 140px;
+  margin-top: 16px;
   font-weight: 700;
 `;

--- a/src/pages/ProfileEditPage/index.jsx
+++ b/src/pages/ProfileEditPage/index.jsx
@@ -1,26 +1,35 @@
+/* eslint-disable guard-for-in */
 import { useNavigate } from 'react-router-dom';
 import * as S from './style';
 import PageTemplate from '../../feature/pageTemplate/PageTemplate';
 import { putPassword } from '../../apis/settings';
 import { PASSWORD_UPDATE_SUCCESS } from '../../commons/constants/string';
 import { useAuthContext } from '../../contexts/UserProvider';
+import { postProfileImg } from '../../apis';
 
 const ProfileEditPage = () => {
   const navigate = useNavigate();
   const { authUser } = useAuthContext();
 
-  const handleChangePassword = async (token, password) => {
+  const handleChangeProfile = async (token, password, profileImgSrc) => {
     const response = await putPassword(token, password);
     if (response === 'Password updated successfully.') {
+      if (profileImgSrc) {
+        const formData = new FormData();
+        formData.append('image', profileImgSrc);
+        formData.append('isCover', false);
+        await postProfileImg(token, formData);
+      }
+
       alert(PASSWORD_UPDATE_SUCCESS);
-      navigate(`/userProfile/${authUser.userId}`); // myUserProfile로 해야할듯
+      navigate(`/userProfile/${authUser.userId}`);
     }
   };
 
   return (
     <S.ProfileEditPageWrapper>
       <PageTemplate>
-        <S.PlacedProfileEditForm onSubmit={handleChangePassword} />
+        <S.PlacedProfileEditForm onSubmit={handleChangeProfile} />
       </PageTemplate>
     </S.ProfileEditPageWrapper>
   );


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
- 프로필 편집 페이지
![스크린샷 2022-06-22 오전 2 58 54](https://user-images.githubusercontent.com/76620786/174867378-4875b76c-73ab-478a-a2cc-bdadecbd27cc.png)

임시적으로 랭크페이지에 profile 이미지 넣어봤습니다 잘되네요!
![스크린샷 2022-06-22 오전 2 59 08](https://user-images.githubusercontent.com/76620786/174867394-c010e195-4c63-417e-85e4-1e34736ba7e3.png)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- ImageUploadContainer (따봉페이지 컴포넌트) 사용
- formData이용해서 api 보내기

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈
close #159 