### PR TITLE
Feat/ Avatar이미지를 보여주기

### DIFF
--- a/src/feature/cards/CardDetail/index.jsx
+++ b/src/feature/cards/CardDetail/index.jsx
@@ -13,12 +13,13 @@ import Icon from '../../../components/Icon';
 const CardDetail = ({
   authorName = '',
   authorId = '',
-  authorImg,
+  author,
   receiverName = '',
   receiverId = '',
   receiverImg,
   comments = [],
   img,
+  receiver,
   isLike = false,
   likeCount = 0,
   PraiseReason = '',
@@ -28,11 +29,14 @@ const CardDetail = ({
   onClickLike,
   type,
 }) => {
+  console.log(receiver);
   return (
     <Card width={342} height={624}>
       <TTaBongerAndTTaBonged
         authorName={authorName}
         authorId={authorId}
+        author={author}
+        receiver={receiver}
         receiverName={receiverName}
         receiverId={receiverId}
         type={type}

--- a/src/feature/cards/TTaBongerAndTTaBonged/index.jsx
+++ b/src/feature/cards/TTaBongerAndTTaBonged/index.jsx
@@ -9,8 +9,10 @@ import Avatar from '../../../components/Avatar';
 const TTaBongerAndTTaBonged = ({
   authorName,
   authorId,
+  author,
   receiverName,
   receiverId,
+  receiver,
   type,
 }) => {
   const navigator = useNavigate();
@@ -24,7 +26,11 @@ const TTaBongerAndTTaBonged = ({
   };
   return (
     <S.TTaBongsContainer>
-      <Avatar onClick={onClickTTaBoner} avatarName={authorName} />
+      <Avatar
+        onClick={onClickTTaBoner}
+        avatarName={authorName}
+        src={author.image || undefined}
+      />
       <S.TTaBongedContainer>
         <S.TTaBongIconWrapper className={type === 'BigTTaBong' && 'Big'}>
           <img
@@ -34,7 +40,12 @@ const TTaBongerAndTTaBonged = ({
             height="40px"
           />
         </S.TTaBongIconWrapper>
-        <Avatar onClick={onClickTTaBoned} avatarName={receiverName} />
+        {/* {console.log(receiver)} */}
+        <Avatar
+          onClick={onClickTTaBoned}
+          avatarName={receiverName}
+          src={receiver.image || undefined}
+        />
       </S.TTaBongedContainer>
     </S.TTaBongsContainer>
   );

--- a/src/feature/cards/TTaBongerAndTTaBonged/index.jsx
+++ b/src/feature/cards/TTaBongerAndTTaBonged/index.jsx
@@ -7,18 +7,17 @@ import BigTB from '../../../assets/ttabong_card_big.svg';
 import Avatar from '../../../components/Avatar';
 
 const TTaBongerAndTTaBonged = ({
-  authorName,
   authorId,
   author,
   receiverName,
   receiverId,
-  receiver,
+  receiver = { image: null },
   type,
 }) => {
   const navigator = useNavigate();
 
   const onClickTTaBoner = () => {
-    navigator(`/userProfile/${authorId}`);
+    navigator(`/userProfile/${author._id}`);
   };
 
   const onClickTTaBoned = () => {
@@ -28,7 +27,7 @@ const TTaBongerAndTTaBonged = ({
     <S.TTaBongsContainer>
       <Avatar
         onClick={onClickTTaBoner}
-        avatarName={authorName}
+        avatarName={author.fullName}
         src={author.image || undefined}
       />
       <S.TTaBongedContainer>
@@ -52,7 +51,6 @@ const TTaBongerAndTTaBonged = ({
 };
 
 TTaBongerAndTTaBonged.propTypes = {
-  authorName: PropTypes.string.isRequired,
   receiverName: PropTypes.string,
 };
 

--- a/src/pages/CardDetailPage/index.jsx
+++ b/src/pages/CardDetailPage/index.jsx
@@ -35,7 +35,7 @@ const CardDetailPage = () => {
       const { author, title, likes, comments, _id, image } =
         post || DummyData.Posts[0];
       const { type, receiver, content, labels } = JSON.parse(title);
-      const labelArr = Object.values(labels).filter(
+      const labelArr = Object.values(labels || {}).filter(
         (label) => label.length > 0,
       );
       const isLike = likeToggle(likes, authUser.userId); // 접속한 유저의 id 값 넣기
@@ -52,8 +52,9 @@ const CardDetailPage = () => {
         isLike,
         image,
       });
-
-      const receiverUser = await getSpecificUser(receiver._id);
+      console.log(type);
+      // const receiverUser = await getSpecificUser(receiver._id);
+      const receiverUser = DummyData.Users[0];
       setReceivedUser(receiverUser);
 
       setLoading(false);

--- a/src/pages/CardDetailPage/index.jsx
+++ b/src/pages/CardDetailPage/index.jsx
@@ -52,6 +52,10 @@ const CardDetailPage = () => {
         isLike,
         image,
       });
+
+      const receiverUser = await getSpecificUser(receiver._id);
+      setReceivedUser(receiverUser);
+
       setLoading(false);
     };
     getPosts();
@@ -118,10 +122,12 @@ const CardDetailPage = () => {
     <PageTemplate>
       {!isLoading ? (
         <CardDetail
+          author={props.author}
           authorName={props.author.fullName}
           authorId={props.author._id}
-          receiverName={props.receiver.fullName}
-          receiverId={props.receiver._id}
+          receiverName={receivedUser.fullName}
+          receiverId={receivedUser._id}
+          receiver={receivedUser}
           comments={props.comments}
           likeCount={props.likes.length}
           labelItems={props.labels}


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- [] cardDeatil 페이지에서 각 아바타의 이미지 보여주기

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
메인피드 페이지에서도 아바타 이미지를 보여주려면 각 카드마다 api를 호출을 해야 할 것 같습니다 그러면 스크롤 할때마다 총 11번의 api 호출이 발생하는데 그렇게 할까요?

### 🚀 연관된 이슈
close #163 