### PR TITLE
Feat/메인카드에서 빅 따봉 및 라벨리스트 보일수 있게 구현

### DIFF
--- a/src/feature/cards/MainCard/index.jsx
+++ b/src/feature/cards/MainCard/index.jsx
@@ -26,8 +26,10 @@ const MainCard = ({ post, ...props }) => {
 
   const { width } = props;
 
-  const { type, receiver, content, labelItems } = JSON.parse(title.trim());
-
+  const { type, receiver, content, labels } = JSON.parse(title.trim());
+  const labelItems = Object.values(labels || {}).filter(
+    (label) => label.length > 0,
+  );
   const navigate = useNavigate();
   const handleClick = () => navigate(`/cardDetail/${postId}`);
 
@@ -38,6 +40,7 @@ const MainCard = ({ post, ...props }) => {
         <TTaBongerAndTTaBonged
           authorName={author.fullName}
           receiverName={receiver.fullName}
+          type={type}
           isMain
         />
         <Divider size={300} />

--- a/src/feature/cards/MainCard/style.jsx
+++ b/src/feature/cards/MainCard/style.jsx
@@ -52,7 +52,7 @@ export const InfoContainer = styled.div`
 export const LikeContainer = styled.div`
   display: flex;
   justify-content: space-between;
-  margin-top: 16px;
+  margin-top: 0.5rem;
   overflow-x: auto;
   width: 100%;
 `;


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

### 🎨 구현 내용
<img width="323" alt="스크린샷 2022-06-22 오후 4 31 31" src="https://user-images.githubusercontent.com/10705018/174970392-0a1e555c-d457-4e5e-bfa1-77c808277aef.png">

<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈
close #180 