### PR TITLE
Feat/avatar border 컴포넌트 구현

### DIFF
--- a/src/components/AvatarBorder/index.jsx
+++ b/src/components/AvatarBorder/index.jsx
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types';
+import * as S from './style';
+import defaultAvatar from '../../assets/avatar_default.svg';
+
+// avatarName을 상위 컴포넌트에서 안넣어주면 이름 안보이게끔
+const AvatarBorder = ({ king, children }) => {
+  return <S.KingWrapper king={king}>{children}</S.KingWrapper>;
+};
+
+AvatarBorder.propTypes = {
+  king: PropTypes.string,
+};
+
+export default AvatarBorder;

--- a/src/components/AvatarBorder/index.stories.jsx
+++ b/src/components/AvatarBorder/index.stories.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import AvatarBorder from '.';
+
+export default {
+  title: 'Components/AvatarBorder',
+  component: AvatarBorder,
+  argTypes: {
+    size: {
+      defaultValue: 'TTaBong',
+      control: { type: 'radio' },
+      option: ['TTaBong', 'coin'],
+    },
+  },
+};
+export const Default = (args) => {
+  return <AvatarBorder {...args} />;
+};

--- a/src/components/AvatarBorder/style.jsx
+++ b/src/components/AvatarBorder/style.jsx
@@ -1,0 +1,41 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+const TTaBongKingAvatarWrapper = ({ theme }) => css`
+  border: 0.2rem solid transparent;
+  border-radius: 50%;
+  background-image: linear-gradient(#fff, #fff),
+    linear-gradient(
+      to bottom right,
+      ${theme.colors.warm[0]},
+      ${theme.colors.warm[1]}
+    );
+  background-origin: border-box;
+  background-clip: content-box, border-box;
+`;
+
+const CoinKingAvatarWrapper = ({ theme }) => css`
+  border: 0.2rem solid transparent;
+  border-radius: 50%;
+  background-image: linear-gradient(#fff, #fff),
+    linear-gradient(
+      to bottom right,
+      ${theme.colors.praise[1]},
+      ${theme.colors.praise[0]}
+    );
+  background-origin: border-box;
+  background-clip: content-box, border-box;
+`;
+
+export const KingWrapper = styled.div`
+  ${({ king }) => {
+    switch (king) {
+      case 'TTaBong':
+        return TTaBongKingAvatarWrapper;
+      case 'coin':
+        return CoinKingAvatarWrapper;
+      default:
+        return null;
+    }
+  }}
+`;

--- a/src/feature/pageTemplate/Banner/index.jsx
+++ b/src/feature/pageTemplate/Banner/index.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import * as S from './style';
 import Avatar from '../../../components/Avatar';
+import AvatarBorder from '../../../components/AvatarBorder';
+
 // 이모션 변수 사용
 // 현재 문제는 윈도우에서 좌표값이 잡힘 배너는 위에만 박혀있어서 좌표값이 바뀌지 않음
 const Banner = ({ isScrollDown = false }) => {
@@ -27,8 +29,12 @@ const Banner = ({ isScrollDown = false }) => {
     <div>
       {show && (
         <S.BannerContainer className={isScrollDown ? 'hide' : 'show'}>
-          <Avatar size={45} />
-          <Avatar size={45} />
+          <AvatarBorder king="TTaBong">
+            <Avatar size={40} />
+          </AvatarBorder>
+          <AvatarBorder king="coin">
+            <Avatar size={40} />
+          </AvatarBorder>
         </S.BannerContainer>
       )}
     </div>

--- a/src/feature/pageTemplate/Banner/style.jsx
+++ b/src/feature/pageTemplate/Banner/style.jsx
@@ -7,7 +7,7 @@ export const BannerContainer = styled.div`
   left: 0;
   width: 100%;
   min-width: 23rem;
-  height: 7rem;
+  min-height: 7rem;
   padding-top: 3.6rem;
   padding-bottom: 0.5rem;
   display: flex;

--- a/src/feature/pageTemplate/Header/index.jsx
+++ b/src/feature/pageTemplate/Header/index.jsx
@@ -4,17 +4,18 @@ import Avatar from '../../../components/Avatar';
 import Icon from '../../../components/Icon';
 import * as S from './style';
 import Badge from '../../../components/Badge';
+import AvatarBorder from '../../../components/AvatarBorder';
 
 const Header = ({ isScrollDown = false, isAlarm = false }) => {
   return (
     <S.Header isScrollDown={isScrollDown}>
       <S.AvatarContainer>
-        <S.TTaBongKingAvatarWrapper>
+        <AvatarBorder king="TTaBong">
           <Avatar size={30} />
-        </S.TTaBongKingAvatarWrapper>
-        <S.CoinKingAvatarWrapper>
+        </AvatarBorder>
+        <AvatarBorder king="coin">
           <Avatar size={30} />
-        </S.CoinKingAvatarWrapper>
+        </AvatarBorder>
       </S.AvatarContainer>
       <Link to="/">
         <S.PlacedLogo />


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
<img width="346" alt="스크린샷 2022-06-22 오후 5 15 56" src="https://user-images.githubusercontent.com/76620786/174979439-55d2ad06-edb3-43b7-b1f1-0ccf1f367ae6.png">
따봉,코인왕을 깜사는 Border를 베이스 컴포넌트로 빼서 구현했습니다

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- AvatarBorder 베이스 컴포넌트로 만듬
- 헤더와 배너에 적용

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈
close #188