### PR TITLE
#191/refactor/ 메인피드 아바타 이미지를 위해 따봉러앤따봉드 리팩토링

### DIFF
--- a/src/feature/cards/CardDetail/index.jsx
+++ b/src/feature/cards/CardDetail/index.jsx
@@ -11,12 +11,7 @@ import InputForm from '../../../components/InputForm';
 import Icon from '../../../components/Icon';
 
 const CardDetail = ({
-  authorName = '',
-  authorId = '',
   author,
-  receiverName = '',
-  receiverId = '',
-  receiverImg,
   comments = [],
   img,
   receiver,
@@ -32,15 +27,7 @@ const CardDetail = ({
   console.log(receiver);
   return (
     <Card width={342} height={624}>
-      <TTaBongerAndTTaBonged
-        authorName={authorName}
-        authorId={authorId}
-        author={author}
-        receiver={receiver}
-        receiverName={receiverName}
-        receiverId={receiverId}
-        type={type}
-      />
+      <TTaBongerAndTTaBonged author={author} receiver={receiver} type={type} />
       <S.MainSection>
         <S.ContentContainer>
           <S.PraiseContainer>
@@ -77,10 +64,6 @@ const CardDetail = ({
 };
 
 CardDetail.propTypes = {
-  authorName: PropTypes.string.isRequired,
-  authorId: PropTypes.string.isRequired,
-  receiverName: PropTypes.string.isRequired,
-  receiverId: PropTypes.string.isRequired,
   comments: PropTypes.array,
   img: PropTypes.string,
   likeCount: PropTypes.number,

--- a/src/feature/cards/MainCard/index.jsx
+++ b/src/feature/cards/MainCard/index.jsx
@@ -38,8 +38,8 @@ const MainCard = ({ post, ...props }) => {
     <BaseCardContainer width={width || 358} height={204}>
       <S.MainCardContainer onClick={handleClick}>
         <TTaBongerAndTTaBonged
-          authorName={author.fullName}
-          receiverName={receiver.fullName}
+          author={author}
+          receiver={receiver}
           type={type}
           isMain
         />

--- a/src/feature/cards/TTaBongerAndTTaBonged/index.jsx
+++ b/src/feature/cards/TTaBongerAndTTaBonged/index.jsx
@@ -1,21 +1,29 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import * as S from './style';
 import TB from '../../../assets/ttabong_card.svg';
 import BigTB from '../../../assets/ttabong_card_big.svg';
 import Avatar from '../../../components/Avatar';
+import { getSpecificUser } from '../../../apis';
 
-const TTaBongerAndTTaBonged = ({
-  authorName,
-  authorId,
-  author = { image: null },
-  receiverName,
-  receiverId,
-  receiver = { image: null },
-  type,
-  isMain = false,
-}) => {
+const TTaBongerAndTTaBonged = ({ author, receiver, type, isMain = false }) => {
+  const { fullName: authorName, _id: authorId, image: authorImage } = author;
+  const { _id: receiverId, fullName: receiverName } = receiver;
+  const [receiverImage, setReceiverImage] = useState(receiver.image);
+
+  const fetchReceiver = async () => {
+    const specificReceiver = await getSpecificUser(receiver._id);
+
+    setReceiverImage(specificReceiver.image);
+  };
+
+  useEffect(() => {
+    if (!receiverImage) {
+      fetchReceiver();
+    }
+  }, []);
+
   const navigator = useNavigate();
 
   const onClickTTaBoner = () => {
@@ -30,7 +38,7 @@ const TTaBongerAndTTaBonged = ({
       <Avatar
         onClick={!isMain ? onClickTTaBoner : null}
         avatarName={authorName}
-        src={author.image || undefined}
+        src={authorImage || undefined}
       />
       <S.TTaBongedContainer>
         <S.TTaBongIconWrapper className={type === 'BigTTaBong' && 'Big'}>
@@ -45,15 +53,13 @@ const TTaBongerAndTTaBonged = ({
         <Avatar
           onClick={!isMain ? onClickTTaBoned : null}
           avatarName={receiverName}
-          src={receiver.image || undefined}
+          src={receiverImage || undefined}
         />
       </S.TTaBongedContainer>
     </S.TTaBongsContainer>
   );
 };
 
-TTaBongerAndTTaBonged.propTypes = {
-  receiverName: PropTypes.string,
-};
+TTaBongerAndTTaBonged.propTypes = {};
 
 export default TTaBongerAndTTaBonged;

--- a/src/pages/CardDetailPage/index.jsx
+++ b/src/pages/CardDetailPage/index.jsx
@@ -25,21 +25,27 @@ const likeToggle = (likes, userId) => {
 };
 
 const CardDetailPage = () => {
-  const navigator = useNavigate();
   const { authUser } = useAuthContext();
-  const { id } = useParams();
+
+  const { id: postId } = useParams();
+  const navigator = useNavigate();
+
   const commentInput = useRef('');
   const inputRef = useRef(null);
+
   const [isLoading, setLoading] = useState(true);
-  const [receivedUser, setReceivedUser] = useState({});
   const [props, setProps] = useState({});
+  const [receivedUser, setReceivedUser] = useState({});
+
   useEffect(() => {
     const getPosts = async () => {
       setLoading(true);
-      const post = await getSpecificPost(id);
+
+      const post = await getSpecificPost(postId);
       const { author, title, likes, comments, _id, image } =
         post || DummyData.Posts[0];
       const { type, receiver, content, labels } = JSON.parse(title);
+
       const labelArr = Object.values(labels || {}).filter(
         (label) => label.length > 0,
       );
@@ -128,10 +134,6 @@ const CardDetailPage = () => {
       {!isLoading ? (
         <CardDetail
           author={props.author}
-          authorName={props.author.fullName}
-          authorId={props.author._id}
-          receiverName={receivedUser.fullName}
-          receiverId={receivedUser._id}
           receiver={receivedUser}
           comments={props.comments}
           likeCount={props.likes.length}


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->

![image](https://user-images.githubusercontent.com/19660039/174988437-71376fd6-38e8-4690-8edf-21ec7b3c707f.png)

이제 메인피드페이지에서도 아바타이미지가 나옵니다.

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

- 따봉러앤따봉드 리팩토링
- 이에 따라 메인카드, 카드디테일, 카드디테일 페이지 리펙토링
- receiverImage 유무에 따라 없으면 receiver를 api로 받아와서 image 삽입

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈