### PR TITLE
Feat/ UserProfile에 카드 이미지 넣기

### DIFF
--- a/src/feature/Cards/ProfileCard/index.jsx
+++ b/src/feature/Cards/ProfileCard/index.jsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as S from './style';
 import Avatar from '../../../components/Avatar';
 import Label from '../../../components/Label';
 import LabelList from '../LabelList';
 import BaseCardContainer from '../../../components/BaseCardContainer';
+import { getSpecificUser } from '../../../apis';
 
 const ProfileCard = ({ post }) => {
-  const { _id, title, author } = post;
+  const { _id, title, author, image } = post;
   const {
     type = '',
     receiver = '이름',
@@ -25,7 +26,7 @@ const ProfileCard = ({ post }) => {
         max-width="10rem"
       >
         <S.ContentWrapper>
-          <Avatar size={50} avatarName={author.fullName} />
+          <Avatar size={50} avatarName={author.fullName} src={author.image} />
           <S.ContentRightWrapper>
             <S.Title>칭찬 사유</S.Title>
             <S.Content>{content}</S.Content>


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
<img width="381" alt="스크린샷 2022-06-22 오후 6 55 35" src="https://user-images.githubusercontent.com/10705018/175000991-fdbb90b5-1587-483d-b8a2-145c31cd49de.png">

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
 UserProfile에  칭찬 받은카드, 칭찬 한카드의 이미지 넣기 
### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈
close #201 